### PR TITLE
Updated TECIO

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,8 +10,8 @@ LIBS=-ltecio -lnetcdf #-lH5hut -lhdf5
 # Compiler flags. 
 CXXFLAGS=-std=c++11 -Wall -ffast-math -funroll-loops -O3 -fopenmp
 
-INC=#-I/usr/include/hdf5/serial/
-LLINK=#-L/usr/lib/x86_64-linux-gnu/hdf5/serial/
+INC=-I/usr/local/tecplot/360ex_2020r2/include
+LLINK=-L/usr/local/tecplot/360ex_2020r2/bin
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # Find the OS to execute correctly
 UNAME := $(shell uname)


### PR DESCRIPTION
Updated the tecplot library to be the latest distribution and also change the include format. Now the library is not assumed to be on the gcc search path, i.e. in /usr/include or /usr/local/include, but to be in the tecplot install directories, normally /usr/local/tecplot/360ex_"version"/include. As such, the makefile has been modified to include these paths, as this should be the most consistent method moving forward.