### PR TITLE
Improved stability controls

### DIFF
--- a/src/Add.h
+++ b/src/Add.h
@@ -1,12 +1,12 @@
 /*********   WCSPH (Weakly Compressible Smoothed Particle Hydrodynamics) Code   *************/
 /*********        Created by Jamie MacLeod, University of Bristol               *************/
 
-#ifndef CROSS_H
-#define CROSS_H
+#ifndef ADD_H
+#define ADD_H
 
 #include "Var.h"
-// #include "IOFunctions.h"
 #include "Containment.h"
+#include "Neighbours.h"
 #include <random>
 #include <stdint.h>
 #include <time.h>
@@ -187,7 +187,7 @@ void Add_Radial_Points(real const y, SIM& svar, FLUID const& fvar, AERO const& a
 		int ncirc = floor(abs(2.0 * M_PI / dtheta));
 		dtheta = 2.0 * M_PI / real(ncirc);
 		
-		for(real theta = 0.0; theta < 2*M_PI; theta += dtheta)
+		for(real theta = 0.0; theta < 2*M_PI-0.5*dtheta; theta += dtheta)
 		{	/* Create a ring of points */
 			real x = rad * sin(theta);
 			real z = rad * cos(theta);
@@ -217,7 +217,7 @@ void Add_Buffer(SIM& svar, FLUID const& fvar, SPHState& pn)
 {
 	for (size_t ii = svar.totPts - svar.nrefresh; ii < svar.totPts; ++ii)
 	{ /*Fill the vector of the last particles*/
-		pn[ii].b = PartState.BACK_;
+		pn[ii].b = BACK;
 		svar.back.emplace_back(ii);
 	}
 
@@ -232,7 +232,7 @@ void Add_Buffer(SIM& svar, FLUID const& fvar, SPHState& pn)
 			SPHPart const& pi = pn[svar.back[jj]];
 			StateVecD xi = pi.xi;
 			xi[1] -= real(level+1.0)*svar.dx;
-			pn.emplace_back(SPHPart(xi, pi, PartState.BUFFER_, pID));
+			pn.emplace_back(SPHPart(xi, pi, BUFFER, pID));
 			svar.buffer[jj][level] = pID;
 			++pID;
 			++svar.simPts;
@@ -245,7 +245,7 @@ void Add_Buffer(SIM& svar, FLUID const& fvar, SPHState& pn)
 	// {
 	// 	StateVecD xi = pn[pi].xi;
 	// 	xi[1] -= itr*svar.dx;
-	// 	pn.emplace_back(SPHPart(xi, pn[pi], PartState.BACK, pID));
+	// 	pn.emplace_back(SPHPart(xi, pn[pi], BACK, pID));
 	// 	pi = pID;
 	// 	++pID;
 	// 	++svar.simPts;
@@ -254,10 +254,10 @@ void Add_Buffer(SIM& svar, FLUID const& fvar, SPHState& pn)
 	
 }
 
-void CreateDroplet(SIM &svar, const FLUID &fvar, SPHState &pn)
+void CreateDroplet(SIM& svar, FLUID const& fvar, SPHState& pn)
 {
 	size_t pID = svar.totPts;
-	size_t const& pState = PartState.FREE_;
+	size_t const& pState = FREE;
 	StateVecD v = StateVecD::Zero();
 	real rho = fvar.simM/pow(svar.dx,SIMDIM);
 	// real rho = fvar.rho0;
@@ -463,7 +463,7 @@ void CreateDroplet(SIM &svar, const FLUID &fvar, SPHState &pn)
 
 void CreateRDroplet(SIM& svar, FLUID const& fvar, SPHState& pn)
 {
-	size_t const& pState = PartState.FREE_;
+	size_t const& pState = FREE;
 	#if SIMDIM == 3
 		StateVecD xi = StateVecD::Zero();
 		StateVecD v = StateVecD::Zero();
@@ -985,8 +985,8 @@ namespace PoissonSample
 				{
 					processList.push_back(newPoint);
 					// StateVecD Point = newPoint+origin;
-					samplePoints.push_back(SPHPart(newPoint+origin,StateVecD::Zero(),0.0,0.0,0.0,PartState.GHOST_,0));
-					airP.emplace_back(SPHPart(newPoint+origin,vel,press,rho,mass,PartState.GHOST_,pID));
+					samplePoints.push_back(SPHPart(newPoint+origin,StateVecD::Zero(),0.0,0.0,0.0,GHOST,0));
+					airP.emplace_back(SPHPart(newPoint+origin,vel,press,rho,mass,GHOST,pID));
 					pID++;
 					grid.insert(newPoint);
 					// cout << "New Point: " << point(0) << " " << point(1) << endl;
@@ -1048,7 +1048,7 @@ inline void check_if_too_close(Sim_Tree const& NP1_INDEX, real const& sr, SPHSta
 	if(out_dists_sqr[0] > sr)
 	{
 		/* it's far enough away, so point can be added to the array */
-		ghost_particles.emplace_back(SPHPart(xi, vel, dens, mass, press, PartState.GHOST_, pID));
+		ghost_particles.emplace_back(SPHPart(xi, vel, dens, mass, press, GHOST, pID));
 		nGhost++;
 	}
 }
@@ -1226,7 +1226,7 @@ void Check_If_Ghost_Needs_Removing(SIM& svar, FLUID const& fvar, Sim_Tree& NP1_I
 	nanoflann::SearchParams const params(0,0,false);
 	real const search_radius = (2*fvar.H+svar.dx)*(2*fvar.H+svar.dx);
 
-	#pragma omp parallel for
+	#pragma omp parallel for default(shared)
 	for(size_t ii = start; ii < end; ++ii)
 	{
 		uint has_interaction = 0;
@@ -1241,7 +1241,7 @@ void Check_If_Ghost_Needs_Removing(SIM& svar, FLUID const& fvar, Sim_Tree& NP1_I
 
 		for(std::pair<size_t,real> const& jj: matches)
 		{
-			if(pnp1[jj.first].b == PartState.FREE_ || pnp1[jj.first].b == PartState.PIPE_)
+			if(pnp1[jj.first].b == FREE || pnp1[jj.first].b == PIPE)
 			{
 				has_interaction = 1;
 				break;

--- a/src/Aero.h
+++ b/src/Aero.h
@@ -15,7 +15,7 @@
 #include "Var.h"
 #include "Kernel.h"
 
-real GetCd(real const& Re)
+inline real const GetCd(real const& Re)
 {
 	return (1.0+0.197*pow(Re,0.63)+2.6e-04*pow(Re,1.38))*(24.0/(Re+0.00001));
 
@@ -25,7 +25,7 @@ real GetCd(real const& Re)
 	// 	return 0.424;
 }
 
-StateVecD AeroForce(StateVecD const& Vdiff, AERO const& avar, real const mass)
+inline StateVecD const AeroForce(StateVecD const& Vdiff, AERO const& avar, real const mass)
 {
 	real const Re = 2.0*avar.rhog*Vdiff.norm()*avar.L/avar.mug;
 	real const Cdi = GetCd(Re);
@@ -35,260 +35,260 @@ StateVecD AeroForce(StateVecD const& Vdiff, AERO const& avar, real const mass)
 	#else
 	real const Ai = M_PI*avar.L;
 	#endif
-		//Fd[1] = 1.0*Fd[1];
-	//std::cout << "Reynolds: " << Re  << " Cd: " << Cd << " Fd: " << Fd[0] << " " << Fd[1] << std::endl;
+		//acc[1] = 1.0*acc[1];
+	//std::cout << "Reynolds: " << Re  << " Cd: " << Cd << " acc: " << acc[0] << " " << acc[1] << std::endl;
 	return (0.5*avar.rhog*Vdiff.norm()*Vdiff*Cdi*Ai);
 }
 
-/*Gissler et al (2017)*/
-StateVecD GisslerForce(AERO const& avar, StateVecD const& Vdiff, StateVecD const& norm, real const& rho,
-				 real const& lam, real const& woccl)
+/*Sphere-Plate interpolation method - Gissler et al (2017)*/
+inline StateVecD const GisslerForce(AERO const& avar, StateVecD const& Vdiff, StateVecD const& norm, 
+						real const& rho, real const& press, real const& mass, real const& lam, real const& woccl)
 {
 	// real const nfull = avar.nfull;
-
-	// real ymax = Vdiff.squaredNorm()*avar.ycoef;
-	// // ymax = 0.0;
-	// if (ymax > 1.0)
-	// 	ymax = 1.0;
-
 	real const Re = 2.0*rho*Vdiff.norm()*avar.L/avar.mug;
 	
-
-	real const frac2 = std::min(8.0/3.0 * lam, 1.0);
+	real const frac2 = std::min(2.0 * lam, 1.0);
 	real const frac1 = (1.0 - frac2);
 
  	real const Cds  = GetCd(Re);
 
-	// real const Cdl = Cds*(1+2.632*ymax);
-	real const Cdl = Cds;
-	real const	Cdi = frac1*Cdl + 0.5* /*1.37**/frac2;
-
+	real Cdl, Adrop;
+	
 	#if SIMDIM == 3 
-		// real const Adrop = M_PI*pow((avar.L + avar.Cb*avar.L*ymax),2);
-		real const Adrop = M_PI*pow(avar.L,2);
+		if(avar.useDef)
+		{
+			real ymax = Vdiff.squaredNorm()*avar.ycoef;
+			if (ymax > 1.0)
+				ymax = 1.0;
+			Cdl = Cds*(1+2.632*ymax);
+			Adrop = M_PI*pow((avar.L + avar.Cb*avar.L*ymax),2);
+		}
+		else
+		{
+			Cdl = Cds;
+			Adrop = avar.aSphere;
+		}
 	#else
-		// real const Adrop = 2*(avar.L + avar.Cb*avar.L*ymax) /** pow(avar.L,1)*/;
-		real const Adrop = 2*avar.L;
+		if(avar.useDef)
+		{
+			real ymax = Vdiff.squaredNorm()*avar.ycoef;
+			if (ymax > 1.0)
+				ymax = 1.0;
+			 Cdl = Cds*(1+2.632*ymax);
+			Adrop = avar.aSphere + 2*(avar.Cb*avar.L*ymax) /** pow(avar.L,1)*/;
+		}
+		else
+		{
+			Cdl = Cds;
+			Adrop = avar.aSphere;
+		}
 	#endif
 
+	real const Cdi = frac1*Cdl + /* 0.5* */ /*1.37**/frac2;
 	real const Aunocc = (frac1*Adrop + frac2*avar.aPlate);
-
-	// real const Ai = (1.0-(std::max(std::min(woccl,1.0),0.0)))*Aunocc;
-	// real woccl_2 = std::min(1.0,std::max(0.0, Vdiff.normalized().dot(norm.normalized())));
-
 	real const Ai = (1.0 - woccl)*Aunocc;
-
-	// StateVecD F = 0.5*avar.rhog*Vdiff.norm()*Vdiff*Cdi*Ai;
 
 	// cout << "Fractions: " << frac1 << "  " << frac2 << endl;
 	// cout << "Areas: " << Ai << "  " << Adrop << "  " << avar.aPlate << endl;
 	// cout << "Re: " << Re << "  Cds: " << Cdi << "  "  << Cdl << "  " << Cds  << endl;
 	// cout << "F: " << F(0) << "  " << F(1) << endl << endl;
 
-	return 0.5*rho*Vdiff.norm()*Vdiff*Cdi*Ai;
-
+	// return  0.5*rho*Vdiff.norm()*Vdiff*Cdi*Ai / mass;
+	return  0.5 * Vdiff.norm() * Vdiff / (avar.sos*avar.sos) *
+			 avar.gamma * press * Cdi * Ai / mass;
 
 }
 
-StateVecD CalcAeroForce(AERO const& avar, SPHPart const& pi, StateVecD const& Vdiff,
+inline StateVecD const InducedPressure(AERO const& avar, StateVecD const& Vdiff,
+		 StateVecD const& norm, real const& Pbasei, real const& lam, SPHPart const& pi )
+		 
+{
+	real theta = abs(acos(-norm.normalized().dot(Vdiff.normalized())));
+		
+	real Cp_p = 0.0;
+	real Cp_s = 0.0;
+	real Cp_tot = 0.0;
+
+	// if(theta < 2.48073)
+	// {
+	// 	Cp = 1- 4*pow(sin(theta),3);
+	// }
+	// else
+	// {
+	// 	Cp = 0.075;
+	// }
+
+	// if(theta < 2.6399)
+	// {
+	// 	Cp = 1.0 - 2.0*pow(sin(theta),2.0);
+	// }
+	// else
+	// {
+	// 	Cp = 0.075;
+	// }
+
+	// if(theta < 2.4877)
+	// {
+	// 	Cp = 1.0 - 2.5*pow(sin(theta),2.0);
+	// }
+	// else
+	// {
+	// 	Cp = 0.075;
+	// }
+
+	/*Spherical Cp*/
+	if(theta < 2.4455)
+	{
+		Cp_s = 1.0 - (2.25) * pow(sin(theta),2.0);
+	}
+	else
+	{
+		Cp_s = 0.075;
+	}
+
+	/*Plate Cp*/
+	if(theta < 1.570797)
+	{
+		Cp_p = cos(theta);
+	}
+	else if (theta < 1.9918)
+	{
+		Cp_p = -pow(cos(6.0*theta+0.5*M_PI),1.5);
+	}
+	else if (theta < 2.0838)
+	{
+		Cp_p = 5.5836*theta-11.5601;
+	}
+	else
+	{
+		Cp_p = 0.075;
+	}
+
+
+	/* Overall Cp (Ideal to machine learn at some point) */
+	if(pi.curve > 200.0)
+	{
+		if(theta < 1.570796)
+			Cp_tot = 0.5*cos(2.0*theta)+0.5;
+		else
+			Cp_tot = 0.0;
+	}
+	else if (pi.curve > 0.0)
+	{
+		real const frac = (pi.curve) * 5.0e-3;
+		Cp_tot = frac + (1.0-frac)*Cp_p;
+	}
+	else if (pi.curve > -200.0)
+	{
+		real const frac = (pi.curve + 200.0) * 5.0e-3;
+		Cp_tot = frac*Cp_p + (1.0-frac)*Cp_s;
+	}
+	else
+	{
+		Cp_tot = Cp_s;
+	}
+
+	// real Plocali = 0.5*avar.rhog*Vdiff.squaredNorm()*Cp_tot;
+
+	/* Compressible dynamic pressure */
+	real const Plocali = 0.5*Vdiff.squaredNorm()/(avar.sos*avar.sos) * avar.gamma * pi.cellP * Cp_tot;
+	// cout << Plocalj << endl;
+
+	real const Pi = (Plocali/* + Pbasei */);
+	
+	// #pragma omp critical
+	// cout << Cp_s << "  " << Cp_p << "  " << Cp_tot << "  " << theta << "  " << pi.curve << "  " << Pi <<  endl;
+
+	real const Re = pi.cellRho*Vdiff.norm()*avar.L/avar.mug;
+	real const Cdi  = GetCd(Re);
+
+	/* Pure droplet force */
+	StateVecD const acc_drop = 0.5*Vdiff*Vdiff.norm()/(avar.sos*avar.sos) * avar.gamma * pi.cellP
+					* (M_PI*avar.L*avar.L*0.25) * Cdi/pi.m;
+	// aeroD = -Pi * avar.aPlate * norm[ii].normalized();
+
+	/* Induce pressure force */
+	StateVecD const acc_kern =  -/*0.5 **/ Pi * avar.aPlate * norm.normalized()/pi.m;
+	// StateVecD const F_kern = -(Pi/(pi.rho)) * norm;
+
+	/*Next, consider a skin friction force acting parallel to the surface*/
+	real const Vnorm = Vdiff.dot(norm.normalized());
+	StateVecD const Vpar = Vdiff - Vnorm*norm.normalized();
+
+	real const Re_par = pi.cellRho*Vpar.norm()*avar.L/avar.mug;
+	real const Cf = 0.027/pow(Re_par+1e-6,1.0/7.0); /*Prandtl seventh power law for turbulent BL*/
+	// real const Cf = 0;
+
+	// StateVecD const acc_skin = StateVecD::Zero();
+	// StateVecD const acc_skin = 0.5*avar.rhog* Vpar.norm() * Cf * avar.aPlate * Vpar/pi.m;
+	StateVecD const acc_skin = 0.5 * Vpar.norm() * 	Vpar / (avar.sos*avar.sos) *
+			 avar.gamma * pi.cellP * Cf * avar.aPlate / pi.m;
+
+	real const frac1 = std::min(2.0 * lam, 1.0);
+	// real const frac2 = std::min(exp(pi.curve*0.001+200),1.0);
+
+	// #pragma omp critical
+	// {
+	// 	cout << acc_kern[0] << "  " << acc_kern[1] << "  " << acc_kern[2] << "  " 
+	// 		<< acc_skin[0] << "  " << acc_skin[1] << "  " << acc_skin[2] << "  "
+	// 		<< acc_drop[0] << "  " << acc_drop[1] << "  " << acc_drop[2] << endl;
+	// }
+
+	return (frac1 * /*frac2**/ (acc_kern+acc_skin) + (1.0-frac1) * acc_drop);
+}
+
+StateVecD CalcAeroAcc(AERO const& avar, SPHPart const& pi, StateVecD const& Vdiff,
 		StateVecD const& norm, real const& lam, real const& Pbasei)
 {
-	StateVecD Fd= StateVecD::Zero();
+	StateVecD acc = StateVecD::Zero();
 
 	// cout << avar.acase << endl;
 	if( avar.acase == 1)
 	{	/* Original Gissler */
-		Fd = GisslerForce(avar,Vdiff,norm,pi.cellRho,lam,pi.woccl);
+		acc = GisslerForce(avar,Vdiff,norm,pi.cellRho,pi.cellP,pi.m,lam,pi.woccl);
 	}
-	// else if(avar.acase == 2)
-	// {	/* Induced pressure based model */	
-	// 	real theta = acos(-norm.normalized().dot(Vdiff.normalized()));
-		
-	// 	real Cp_p = 0.0;
-	// 	real Cp_s = 0.0;
-	// 	real Cp_tot = 0.0;
-
-	// 	// if(abs(theta) < 2.48073)
-	// 	// {
-	// 	// 	Cp = 1- 4*pow(sin(abs(theta)),3);
-	// 	// }
-	// 	// else
-	// 	// {
-	// 	// 	Cp = 0.075;
-	// 	// }
-
-	// 	// if(abs(theta) < 2.6399)
-	// 	// {
-	// 	// 	Cp = 1.0 - 2.0*pow(sin(abs(theta)),2.0);
-	// 	// }
-	// 	// else
-	// 	// {
-	// 	// 	Cp = 0.075;
-	// 	// }
-
-	// 	// if(abs(theta) < 2.4877)
-	// 	// {
-	// 	// 	Cp = 1.0 - 2.5*pow(sin(abs(theta)),2.0);
-	// 	// }
-	// 	// else
-	// 	// {
-	// 	// 	Cp = 0.075;
-	// 	// }
-
-	// 	/*Spherical Cp*/
-	// 	if(abs(theta) < 2.3187)
-	// 	{
-	// 		Cp_s = 1.0 - 2*pow(sin(abs(theta)),2.0);
-	// 	}
-	// 	else
-	// 	{
-	// 		Cp_s = 0.075;
-	// 	}
-
-	// 	/*Plate Cp*/
-	// 	if(abs(theta) < 1.570796)
-	// 	{
-	// 		Cp_p = cos(abs(theta));
-	// 	}
-	// 	else if (abs(theta) < 1.9918)
-	// 	{
-	// 		Cp_p = -pow(cos(6.0*abs(theta)+M_PI/2.0),1.5);
-	// 	}
-	// 	else if (abs(theta) < 2.0838)
-	// 	{
-	// 		Cp_p = 5.5836*abs(theta)-11.5601;
-	// 	}
-	// 	else
-	// 	{
-	// 		Cp_p = 0.075;
-	// 	}
-
-
-	// 	// /*Overall Cp*/
-	// 	// if(pi.curve > 200.0)
-	// 	// {
-	// 	// 	if(abs(theta) < 1.570796)
-	// 	// 		Cp_tot = 0.5*cos(2.0*abs(theta))+0.5;
-	// 	// 	else
-	// 	// 		Cp_tot = 0.0;
-	// 	// }
-	// 	// else if (pi.curve > 0.0)
-	// 	// {
-	// 	// 	real frac = (pi.curve)/(200.0);
-	// 	// 	Cp_tot = frac + (1.0-frac)*Cp_p;
-	// 	// }
-	// 	// else if (pi.curve > -200.0)
-	// 	// {
-	// 	// 	real frac = (pi.curve + 200.0)/(200.0);
-	// 	// 	Cp_tot = frac*Cp_p + (1.0-frac)*Cp_s;
-	// 	// }
-	// 	// else
-	// 	// {
-	// 	// 	Cp_tot = Cp_s;
-	// 	// }
-
-
-	// 	real Plocali = 0.5*avar.rhog*Vdiff.squaredNorm()*Cp_tot;
-	// 	// cout << Plocalj << endl;
-
-	// 	real Pi = (Plocali+Pbasei);
-
-	// 	// real sph_d = sqrt(pi.m/pi.rho);
-
-	// 	real const Re = avar.rhog*Vdiff.norm()*avar.L/avar.mug;
-	// 	real const Cdi  = GetCd(Re);
-
-
-	// 	// cout << Cdi << endl;
-	// 	StateVecD const F_drop = 0.5*avar.rhog*Vdiff.norm()*Vdiff*(M_PI*avar.L*avar.L/4)*Cdi/pi.m;
-	// 	// aeroD = -Pi * avar.aPlate * norm[ii].normalized();
-
-	// 	// StateVecD const F_kern = -(Pi/(pi.rho)) * norm;
-	// 	StateVecD const F_kern = - /*0.5 **/ Pi * avar.aPlate * norm.normalized()/pi.m;
-
-	// 	real const frac1 = std::min(3.0/2.0 * lam, 1.0);
-	// 	// real const frac2 = std::min(exp(pi.curve*0.001+200),1.0);
-
-	// 	real frac3 = 1.0;
-	// 	// if(avar.dPipe != 0.0)
-	// 	// {
-	// 	// 	if(pi.pDist < avar.dPipe)
-	// 	// 	{
-	// 	// 		/*Smooth the aerodynamic force near the pipe*/
-	// 	// 		frac3 = 1.0-Kernel(pi.pDist,0.5*avar.dPipe,1.0);
-	// 	// 	}
-	// 	// }
-	// 	// cout << F_kern.norm() << "  " << F_drop.norm() << endl;
-	// 	// cout << avar.nfull << "  " << frac1  << "  " << real(size-1) << endl;
-
-
-	// 	Fd = frac3*(frac1*/*frac2**/F_kern + (1.0-frac1)*F_drop);
-	// }
+	else if(avar.acase == 2)
+	{	/* Induced pressure based model */	
+		acc = InducedPressure(avar,Vdiff,norm,Pbasei,lam,pi);
+	}
 	else if (avar.acase == 3)
 	{	/*Skin Friction Method*/
 		/*Calculate the component of velocity in the surface normal direction (scalar projection)*/
-		real Vnorm = -Vdiff.dot(norm.normalized());
+		real Vnorm = Vdiff.dot(norm.normalized());
 
 		if(Vnorm > 0.001)
 		{
-
 			real const Re = avar.rhog*Vdiff.norm()*avar.L/avar.mug;
 
-			/*Consider that pressure force is the stagnation of a velocity parallel to the surface*/
+			/*Consider that pressure force is the stagnation of a velocity normal to the surface*/
 			/*i.e. enforcing no parallel flow pressure and Cp = 1. */
-			StateVecD Fpress = -0.5*avar.rhog*Vnorm*Vnorm*avar.aPlate * norm.normalized()/pi.m;
+			StateVecD acc_press = 0.5*avar.rhog*Vnorm*Vnorm*avar.aPlate * norm.normalized()/pi.m;
 
 			/*Next, consider a skin friction force acting parallel to the surface*/
 			StateVecD Vpar = Vdiff - abs(Vnorm)*norm.normalized();
 			real Cf = 0.027/pow(Re,1.0/7.0); /*Prandtl seventh power law for turbulent BL*/
 
-			StateVecD Fskin = 0.5*avar.rhog*Vpar.norm() * Cf * avar.aPlate * Vpar/pi.m;
+			StateVecD acc_skin = 0.5*avar.rhog* Vpar.norm() * Cf * avar.aPlate * Vpar/pi.m;
 
-			real const frac2 = std::min(3.0/2.0 * lam, 1.0);
+			real const frac2 = std::min(1.5 * lam, 1.0);
 			real const frac1 = (1.0 - frac2);
-
 
 			/*Droplet force*/
 			real const Cdi = GetCd(Re);
-			StateVecD const F_drop = 0.5*avar.rhog*Vdiff.norm()*Vdiff*(M_PI*avar.L*avar.L/4)*Cdi/pi.m;
+			StateVecD const acc_drop = 0.5*avar.rhog*Vdiff.norm()*Vdiff*(M_PI*avar.L*avar.L/4)*Cdi/pi.m;
 
 			// cout << Fpress(0) << "  " << Fpress(1) << "  " << Fskin(0) << "  " << Fskin(1) << endl;
 
-			Fd = frac2*(Fpress + Fskin) + frac1*F_drop;
-
+			acc = frac2*(acc_press + acc_skin) + frac1*acc_drop;
 		}
 
 	}
 	else if(avar.acase == 4)
-	{ /*Surface particles, with correction based on surface normal*/
-		// cout << size << endl;
-		// if (size < avar.nfull)
-		// {
-		// 	Fd = AeroForce(Vdiff, avar, pi.m);
-		// 	/*Correction based on surface tension vector*/
-		// 	real correc = 1.0;
-		// 	if(size > 0.1 * avar.nfull)
-		// 	{
-		// 		real num = norm.dot(Vdiff);
-		// 		real denom = norm.norm()*(Vdiff).norm();
-		// 		real theta = num/denom;
-				
-		// 		if (theta <= 1.0  && theta >= -1.0)
-		// 		{
-		// 			correc = avar.a*Kernel(1-theta,avar.h1,1)+
-		// 				avar.b*Kernel(1-theta,avar.h2,1);
-		// 		}
-		// 	}
-		// 	Fd = /*avar.Acorrect**/correc*Fd;
-		// }
-		
-	}
-	else if(avar.acase == 5)
 	{
 
 		// real ymax = Vdiff.squaredNorm()*avar.ycoef;
 
-		// Fd = AeroForce(Vdiff, avar, pi.m);
+		// acc = AeroForce(Vdiff, avar, pi.m);
 		// real correc = 1.0;
 		// real Acorrect = 1.0-woccl;
 
@@ -298,7 +298,7 @@ StateVecD CalcAeroForce(AERO const& avar, SPHPart const& pi, StateVecD const& Vd
 		// real theta = num/denom;
 
 		real Cp = 0.0;
-		if(abs(theta) < 2.4435)
+		if(theta < 2.4435)
 		{
 			Cp = 1.1*cos(theta*2.03)-0.1;
 		}
@@ -307,56 +307,30 @@ StateVecD CalcAeroForce(AERO const& avar, SPHPart const& pi, StateVecD const& Vd
 			Cp = 0.075;
 		}
 
-		real const frac2 = std::min(3.0/2.0 * lam, 1.0);
+		real const frac2 = std::min(1.5 * lam, 1.0);
 		real const frac1 = (1.0 - frac2);
 
 
 		#if SIMDIM == 3 
-					// real const Adrop = M_PI*pow((avar.L + avar.Cb*avar.L*ymax),2);
-					real const Adrop = M_PI*pow(avar.L,2);
-		#endif
-		#if SIMDIM == 2
-					// real const Adrop = 2*(avar.L + avar.Cb*avar.L*ymax);
-					real const Adrop = 2*avar.L;
+			// real const Adrop = M_PI*pow((avar.L + avar.Cb*avar.L*ymax),2);
+			real const Adrop = M_PI*pow(avar.L,2);
+		#else
+			// real const Adrop = 2*(avar.L + avar.Cb*avar.L*ymax);
+			real const Adrop = 2*avar.L;
 		#endif
 
 		real const Aunocc = frac1*Adrop + frac2*avar.aPlate;
 
-		// #if SIMDIM == 2
-		// 			real area = avar.L;
-		// #else
-		// 			real area = M_PI*avar.L*avar.L;
-		// #endif
-
-			real press = 0.5*avar.rhog*Vdiff.squaredNorm()*Cp;
+		real press = 0.5*avar.rhog*Vdiff.squaredNorm()*Cp;
 
 		#if SIMDIM == 3
-					Fd = -7.5*norm.normalized()*Aunocc*press;
+			acc = -7.5*norm.normalized()*Aunocc*press;
 		#else
-					Fd = -norm.normalized()*Aunocc*press;
+			acc = -norm.normalized()*Aunocc*press;
 		#endif
-
-		// if (theta <= 1.0  && theta >= -1.0)
-		// {
-		// 	correc = avar.a*W2Kernel(1-theta,avar.h1,1)+
-		// 		avar.b*W2Kernel(1-theta,avar.h2,1);
-		// }
-		
-		// /*Correct based on the number of neighbours*/
-		// Acorrect = 0.9995*exp(-0.04606*real(size))+0.0005;
-		// cout << size << "  " << Acorrect << endl;
-		
-
-		// Fd = correc*Acorrect*Fd;
-		
 	}
-	// else if(avar.acase == 6)
-	// {	
-	// 	/* All upstream particles */
-	// 	// Fd = pi.woccl*avar.Acorrect*AeroForce(Vdiff, avar, pi.m);
-	// }
 
-	return Fd;
+	return acc;
 }
 
 

--- a/src/BinaryIO.h
+++ b/src/BinaryIO.h
@@ -8,16 +8,11 @@
 #include "Var.h"
 #include "Neighbours.h"
 #include "Kernel.h"
-#include <string.h>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
 #include <sys/stat.h>
 #include <chrono>
 #include <thread>
 using std::string;
 
-enum fileType_e { FULL = 0, GRID = 1, SOLUTION = 2 };
 
 /*************************************************************************/
 /**************************** BINARY INPUTS ******************************/
@@ -27,11 +22,11 @@ void Read_Real_Value(void* const& inputHandle, int32_t const& frame, int32_t& va
 {
 	int retval;
 	vector<real> varvec(iMax);
-#if FOD == 1
-	retval = tecZoneVarGetDoubleValues(inputHandle, frame, varCount, 1, iMax, &varvec[0]);
-#else
-	retval = tecZoneVarGetFloatValues(inputHandle, frame, varCount, 1, iMax, &varvec[0]);
-#endif
+	#if FOD == 1
+		retval = tecZoneVarGetDoubleValues(inputHandle, frame, varCount, 1, iMax, &varvec[0]);
+	#else
+		retval = tecZoneVarGetFloatValues(inputHandle, frame, varCount, 1, iMax, &varvec[0]);
+	#endif
 
 	if(retval)
 	{
@@ -77,11 +72,11 @@ void Read_Real_Vector(void* const& inputHandle, int32_t const& frame, int32_t& v
 {
 	int retval;
 	var = vector<real>(iMax);
-#if FOD == 1
-	retval = tecZoneVarGetDoubleValues(inputHandle, frame, varCount, 1, iMax, &var[0]);
-#else
-	retval = tecZoneVarGetFloatValues(inputHandle, frame, varCount, 1, iMax, &var[0]);
-#endif
+	#if FOD == 1
+		retval = tecZoneVarGetDoubleValues(inputHandle, frame, varCount, 1, iMax, &var[0]);
+	#else
+		retval = tecZoneVarGetFloatValues(inputHandle, frame, varCount, 1, iMax, &var[0]);
+	#endif
 
 	if(retval)
 	{
@@ -145,13 +140,13 @@ vector<StateVecD> Read_Binary_Vector(void* inputHandle, INTEGER4& frame,
 	name.append(varName);
 	Read_Real_Vector(inputHandle, frame, varCount, iMax, yVar, name);
 
-#if SIMDIM == 3
+	#if SIMDIM == 3
 	vector<real> zVar(iMax,0.0);
 	// cout << "Trying to get vector z-component. Var: " << varCount << endl;
 	name = "z-component of ";
 	name.append(varName);
 	Read_Real_Vector(inputHandle, frame, varCount, iMax, zVar, name);
-#endif
+	#endif
 
 	vector<StateVecD> vec(iMax);
 	#pragma omp parallel for
@@ -160,9 +155,9 @@ vector<StateVecD> Read_Binary_Vector(void* inputHandle, INTEGER4& frame,
 		vec[ii](0) = xVar[ii];
 		vec[ii](1) = yVar[ii];
 		
-#if SIMDIM == 3
+	#if SIMDIM == 3
 		vec[ii](2) = zVar[ii];
-#endif
+	#endif
 
 		// cout << tsData.verts[ii](0) << "  " << tsData.verts[ii](1) << endl;
 	}
@@ -270,71 +265,71 @@ void Read_Binary_Timestep(void* inputHandle, SIM& svar, int32_t frame, SPHState&
 /*************************************************************************/
 /*************************** BINARY OUTPUTS ******************************/
 /*************************************************************************/
-void Write_Real_Vector(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int64_t const& size,
+void Write_Real_Vector(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int32_t const& size,
 						vector<real> const& varVec, string const& varName)
 {
 	int retval;
-#if FOD == 1
-	retval =  tecZoneVarWriteDoubleValues(fileHandle, outputZone, varCount, 0, size, &varVec[0]);
-#else
-	retval =  tecZoneVarWriteFloatValues(fileHandle, outputZone, varCount, 0, size, &varVec[0]);
-#endif	
+	#if FOD == 1
+		retval =  tecZoneVarWriteDoubleValues(fileHandle, outputZone, varCount, 0, size, &varVec[0]);
+	#else
+		retval =  tecZoneVarWriteFloatValues(fileHandle, outputZone, varCount, 0, size, &varVec[0]);
+	#endif	
 
 	if(retval)
 	{
-		cout << "Failed to read \"" << varName << "\". frame: " << 
+		cout << "Failed to write \"" << varName << "\". frame: " << 
 			outputZone << ". varCount: " << varCount << endl;
 		exit(-1);
 	}
 	varCount++;
 }
 
-void Write_Int_Vector(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int64_t const& size,
+void Write_Int_Vector(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int32_t const& size,
 						vector<int32_t> const& varVec, string const& varName)
 {
 	if(tecZoneVarWriteInt32Values(fileHandle, outputZone, varCount, 0, size, &varVec[0]))
 	{
-		cout << "Failed to read \"" << varName << "\". frame: " << 
+		cout << "Failed to write \"" << varName << "\". frame: " << 
 			outputZone << ". varCount: " << varCount << endl;
 		exit(-1);
 	}
 	varCount++;
 }
 
-void Write_UInt_Vector(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int64_t const& size,
+void Write_UInt_Vector(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int32_t const& size,
 						vector<uint8_t> const& varVec, string const& varName)
 {
 	if(tecZoneVarWriteUInt8Values(fileHandle, outputZone, varCount, 0, size, &varVec[0]))
 	{
-		cout << "Failed to read \"" << varName << "\". frame: " << 
+		cout << "Failed to write \"" << varName << "\". frame: " << 
 			outputZone << ". varCount: " << varCount << endl;
 		exit(-1);
 	}
 	varCount++;
 }
 
-void Write_Real_Value(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int64_t const& size,
+void Write_Real_Value(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int32_t const& size,
 						real const& value, string const& varName)
 {
 	int retval;
 	vector<real> rvec(size,0.0);
 	rvec[0] = value;
-#if FOD == 1
-	retval = tecZoneVarWriteDoubleValues(fileHandle, outputZone, varCount, 0, size, &rvec[0]);
-#else
-	retval = tecZoneVarWriteFloatValues(fileHandle, outputZone, varCount, 0, size, &rvec[0]);
-#endif	
+	#if FOD == 1
+		retval = tecZoneVarWriteDoubleValues(fileHandle, outputZone, varCount, 0, size, &rvec[0]);
+	#else
+		retval = tecZoneVarWriteFloatValues(fileHandle, outputZone, varCount, 0, size, &rvec[0]);
+	#endif	
 
 	if(retval)
 	{
-		cout << "Failed to read \"" << varName << "\". frame: " << 
+		cout << "Failed to write \"" << varName << "\". frame: " << 
 			outputZone << ". varCount: " << varCount << endl;
 		exit(-1);
 	}
 	varCount++;
 }
 
-void Write_Int_Value(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int64_t const& size,
+void Write_Int_Value(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int32_t const& size,
 						int32_t const& value, string const& varName)
 {
 	int retval;
@@ -345,14 +340,14 @@ void Write_Int_Value(void* const& fileHandle, int32_t const& outputZone, int32_t
 
 	if(retval)
 	{
-		cout << "Failed to read \"" << varName << "\". frame: " << 
+		cout << "Failed to write \"" << varName << "\". frame: " << 
 			outputZone << ". varCount: " << varCount << endl;
 		exit(-1);
 	}
 	varCount++;
 }
 
-void Write_UInt_Value(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int64_t const& size,
+void Write_UInt_Value(void* const& fileHandle, int32_t const& outputZone, int32_t& varCount, int32_t const& size,
 						uint8_t const& value, string const& varName)
 {
 	int retval;
@@ -363,7 +358,7 @@ void Write_UInt_Value(void* const& fileHandle, int32_t const& outputZone, int32_
 
 	if(retval)
 	{
-		cout << "Failed to read \"" << varName << "\". frame: " << 
+		cout << "Failed to write \"" << varName << "\". frame: " << 
 			outputZone << ". varCount: " << varCount << endl;
 		exit(-1);
 	}
@@ -373,7 +368,7 @@ void Write_UInt_Value(void* const& fileHandle, int32_t const& outputZone, int32_
 void Write_Binary_Timestep(SIM const& svar, SPHState const& pnp1, 
 	uint const start, uint const end, char const* group, int32_t const& strandID, void* const& fileHandle)
 {
-	int64_t const size = end - start;
+	int32_t const size = end - start;
 
 	double solTime = svar.t;     
 	int32_t outputZone;
@@ -628,94 +623,95 @@ void Write_Binary_Timestep(SIM const& svar, SPHState const& pnp1,
     }
 }
 
+
+
 void Init_Binary_PLT(SIM &svar, string const& filename, string const& zoneName, void* &fileHandle)
 {
     int32_t FileType   = 0; /*0 = Full, 1 = Grid, 2 = Solution*/
     int32_t fileFormat = 1; // 0 == PLT, 1 == SZPLT
 
-    string file = svar.output_prefix;
-    file.append(filename);
+    string file = svar.output_prefix + filename;
 
     // cout << file << endl;
 
     /* Open the file and write the tecplot datafile header information  */
-#if SIMDIM == 2
-    	std::string variables = "X,Z";	
-		if (svar.outform == 1)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v,a,partID";
-		}
-		else if (svar.outform == 2)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID";
-		}
-		else if (svar.outform == 3)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,Cell_Vx,Cell_Vz,Cell_P,Cell_Rho,Cell_ID";
-		}
-		else if (svar.outform == 4)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v,a,partID,Neighbours,Aero";
-		}
-		else if (svar.outform == 5)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,Cell_ID";
-		}
-		else if (svar.outform == 6)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,lambda,surface";
-		}
-		else if (svar.outform == 7)
-		{
-			variables = "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z";
-		}
-#endif
+	#if SIMDIM == 2
+		std::string variables;
+		std::string a1, a2;
 
-#if SIMDIM == 3
-		std::string variables = "X,Y,Z";  
+		if(svar.offset_axis == 1)
+		{
+			variables = "Y,Z";
+			a1 = "y";
+			a2 = "z";
+		}
+		else if (svar.offset_axis == 2)
+    	{
+			variables = "X,Z";
+			a1 = "x";
+			a2 = "z";
+		}
+		else if (svar.offset_axis == 3)
+		{
+			variables = "X,Y";
+			a1 = "x";
+			a2 = "y";
+		}
+
+		if(svar.outform > 0)
+			variables += ",Rrho,rho,press,m";
+
 		if (svar.outform == 1)
-		{
-			variables = "X,Y,Z,Rrho,rho,press,m,v,a,partID";
-		}
+			variables += ",v,a,partID";
 		else if (svar.outform == 2)
-		{
-			variables = "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID";
-		}
+			variables += ",v_"+a1+",v_"+a2+",a_"+a1+",a_"+a2+",b,partID";
 		else if (svar.outform == 3)
-		{
-			variables = 
-		"X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_Vx,Cell_Vy,Cell_Vz,Cell_P,Cell_Rho,Cell_ID";
-		}
+			variables += ",v_"+a1+",v_"+a2+",a_"+a1+",a_"+a2+",b,partID,Cell_V"+a1+",Cell_V"+a2+",Cell_P,Cell_Rho,Cell_ID";
 		else if (svar.outform == 4)
-		{
-			variables = "X,Y,Z,Rrho,rho,press,m,v,a,partID,Neighbours,Aero";
-		}
+			variables += ",v,a,partID,Neighbours,Aero";
 		else if (svar.outform == 5)
-		{
-			variables = "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_ID";
-		}
+			variables += ",v_"+a1+",v_"+a2+",a_"+a1+",a_"+a2+",b,partID,Cell_ID";
 		else if (svar.outform == 6)
-		{
-			variables = "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface";
-		}
+			variables += ",v_"+a1+",v_"+a2+",a_"+a1+",a_"+a2+",b,partID,lambda,surface";
 		else if (svar.outform == 7)
-		{
-			variables = "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z";
-		}
-#endif
+			variables += ",v_"+a1+",v_"+a2+",a_"+a1+",a_"+a2+",b,partID,lambda,surface,a_aero_"+a1+",a_aero_"+a2;
+
+	#endif
+
+	#if SIMDIM == 3
+		std::string variables = "X,Y,Z";  
+		if(svar.outform > 0)
+			variables += ",Rrho,rho,press,m";
+
+		if (svar.outform == 1)
+			variables += ",v,a,partID";
+		else if (svar.outform == 2)
+			variables += ",v_x,v_y,v_z,a_x,a_y,a_z,b,partID";
+		else if (svar.outform == 3)
+			variables += 
+		",v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_Vx,Cell_Vy,Cell_Vz,Cell_P,Cell_Rho,Cell_ID";
+		else if (svar.outform == 4)
+			variables += ",v,a,partID,Neighbours,Aero";
+		else if (svar.outform == 5)
+			variables += ",v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_ID";
+		else if (svar.outform == 6)
+			variables += ",v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface";
+		else if (svar.outform == 7)
+			variables += ",v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z";
+	#endif
 
 	vector<int32_t> varTypes;
-#if FOD == 1
-	int32_t realType = 2;
-#else
-	int32_t realType = 1;
-#endif
+	#if FOD == 1
+		int32_t realType = 2;
+	#else
+		int32_t realType = 1;
+	#endif
 
 	varTypes.emplace_back(realType);
 	varTypes.emplace_back(realType);
-#if SIMDIM == 3
-	varTypes.emplace_back(realType);	//x,y,z
-#endif
+	#if SIMDIM == 3
+		varTypes.emplace_back(realType);	//x,y,z
+	#endif
 	if(svar.outform != 0)
 	{
 		varTypes.emplace_back(realType);  //Rrho
@@ -741,10 +737,10 @@ void Init_Binary_PLT(SIM &svar, string const& filename, string const& zoneName, 
 			varTypes.emplace_back(realType);  //vy
 			varTypes.emplace_back(realType);  //ax
 			varTypes.emplace_back(realType);  //ay
-#if SIMDIM == 3
+			#if SIMDIM == 3
 			varTypes.emplace_back(realType);  //vz
 			varTypes.emplace_back(realType);  //az
-#endif
+			#endif
 			varTypes.emplace_back(5);  //b
 			varTypes.emplace_back(3);  //part_ID
 
@@ -782,6 +778,9 @@ void Init_Binary_PLT(SIM &svar, string const& filename, string const& zoneName, 
 		}
 	}
 	svar.varTypes = varTypes;
+	cout << "Offset axis: " << svar.offset_axis << endl;
+	cout << "Variables: " << variables << endl;
+	cout << "varTypes size: " << svar.varTypes.size() << endl;
 
 	if(tecFileWriterOpen(file.c_str(),zoneName.c_str(),variables.c_str(),fileFormat,FileType,1,NULL,&fileHandle))
     {
@@ -789,23 +788,22 @@ void Init_Binary_PLT(SIM &svar, string const& filename, string const& zoneName, 
     	exit(-1);
     }
 
-#ifdef DEBUG
+	#ifdef DEBUG
 	if(tecFileSetDiagnosticsLevel(fileHandle, 1))
 	{
 		cerr << "Failed to set debug option for output file: " << file << endl;
 		exit(-1);
 	}
-
-#endif
+	#endif
 
     
 }
 
 void Write_Cell_Data(MESH const& cdata)
 {
-#ifdef DEBUG
-	dbout << "Entering Write_Cell_Data..." << endl;
-#endif
+	#ifdef DEBUG
+		dbout << "Entering Write_Cell_Data..." << endl;
+	#endif
 
 	cout << "Writing cell based data." << endl;
 
@@ -844,23 +842,40 @@ void Write_Cell_Data(MESH const& cdata)
 		if (kk % 5 != 0)
 			fout << "\n";
 	}
-
+	
 	/*Write element indexing*/
 	fout << std::fixed;
-	for (uint ii = 0; ii < cdata.elems.size(); ++ii)
+	for (uint index = 0; index < cdata.cFaces.size(); ++index)
 	{
-		for (auto elem : cdata.elems[ii])
+		/* Build the element unique index list */
+		vector<size_t> elem;
+		for (auto const& faceID: cdata.cFaces[index])
 		{
-			fout << std::setw(6) << elem + 1;
+			vector<size_t> const face = cdata.faces[faceID];
+			for (auto const& vert : face)
+			{
+				if (std::find(elem.begin(), elem.end(), vert) == elem.end())
+				{ /*Vertex doesn't exist in the elems vector yet.*/
+					#pragma omp critical
+					{
+						elem.emplace_back(vert);
+					}
+				}
+			}
+		}
+
+		for (auto const& vert : elem)
+		{
+			fout << std::setw(6) << vert + 1;
 		}
 		fout << "\n";
 	}
 
 	fout.close();
 
-#ifdef DEBUG
-	dbout << "Exiting Write_Cell_Data..." << endl;
-#endif
+	#ifdef DEBUG
+		dbout << "Exiting Write_Cell_Data..." << endl;
+	#endif
 }
 
 void Write_Face_Data(MESH const& cells)
@@ -971,6 +986,406 @@ void Write_Face_Data(MESH const& cells)
 	f1 << endl	<< endl;
 	f1.close();
 	// exit(0);
+}
+
+
+void CheckContents(void* const& inputHandle, SIM& svar, int32_t& numZones, double& time)
+{
+	int32_t numVars, I;
+	I = tecDataSetGetNumVars(inputHandle, &numVars);
+
+	std::ostringstream outputStream;
+    for (int32_t var = 1; var <= numVars; ++var)
+    {
+        char* name = NULL;
+        I = tecVarGetName(inputHandle, var, &name);
+        outputStream << name;
+        if (var < numVars)
+            outputStream << ',';
+        tecStringFree(&name);
+    }
+
+	if (I == -1)
+	{
+		cout << "Couldn't obtain number of variables. Stopping" << endl;
+		exit(-1);
+	}
+
+	cout << "Number of variables in output file: " << numVars << endl;
+
+	uint dataType = 0;
+	#if SIMDIM == 2
+		if( outputStream.str() == "X,Z")
+			dataType = 0;
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v,a,partID")
+			dataType = 1;
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID")
+			dataType = 2;	
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,Cell_Vx,Cell_Vz,Cell_P,Cell_Rho,Cell_ID" )
+			dataType = 3;
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v,a,partID,Neighbours,Aero")
+			dataType = 4;
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,Cell_ID")
+			dataType = 5;
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,lambda,surface")
+			dataType = 6;
+
+		else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z")
+			dataType = 7;
+
+	#else
+		if( outputStream.str() == "X,Y,Z")
+			dataType = 0;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v,a,partID")
+			dataType = 1;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID")
+			dataType = 2;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_Vx,Cell_Vy,Cell_Vz,Cell_P,Cell_Rho,Cell_ID")
+			dataType = 3;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v,a,partID,Neighbours,Aero")
+			dataType = 4;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_ID")
+			dataType = 5;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface")
+			dataType = 6;
+
+		else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z")
+			dataType = 7;
+		
+	#endif
+	cout << "Variables:  " << outputStream.str() << "  Data type: " << dataType << endl;
+
+	if(dataType == 0 || dataType == 1 || dataType == 4)
+	{
+		cout << "Cannot restart. File does not contain the correct information." << endl;
+		exit(-1);
+	}
+
+    if(dataType!= svar.outform)
+    {
+    	cout << "Data is different from that in the restfings file." << endl;
+    	cout << "Changing to the file data type: " << dataType << endl;
+    }
+
+    I = tecDataSetGetNumZones(inputHandle, &numZones);
+    cout << "Number of zones in file: " << numZones << endl;
+
+    I = tecZoneGetSolutionTime(inputHandle, numZones, &time);
+    cout << "Latest zone time: " << time << endl << endl;
+}
+
+void Restart_Binary(SIM& svar, FLUID const& fvar, AERO const& avar, MESH const& cells, SPHState& pn, SPHState& pnp1)
+{	
+	// Read the values from the solution folder, then check. 
+
+	// Check that a restart can be performed. 
+	if(svar.outform == 0 || svar.outform == 1)
+	{
+		cout << "Output type cannot be restarted from. Make sure that you have the correct output selected." << endl;
+		exit(-1);
+	}
+
+	// if(svar.Asource != 0)
+	// {
+	// 	if(svar.outform != 3 || svar.outform != 5)
+	// 	{
+	// 		cout << "No cell information. Cannot restart" << endl;
+	// 		exit(-1);
+	// 	}
+	// }
+
+	#ifdef DEBUG
+		dbout << "Reading frame info file for restart information." << endl;
+	#endif
+
+	// Re-read the settings and fluid file
+	// cout << svar.outfolder << endl;
+
+	// Now get the data from the files. Start with the boundary
+	if(svar.out_encoding == 1)
+	{
+		SPHState boundary, fuel, rest;	
+
+		// Read the fuel
+		void* fuelHandle = NULL;
+		void* boundHandle = NULL;
+
+		int32_t fuelFrames, boundFrames;
+		double fuelTime, boundTime;
+
+		string fuelf = svar.output_prefix;
+		fuelf.append("_fuel.szplt");
+
+		if(tecFileReaderOpen(fuelf.c_str(),&fuelHandle))
+		{
+			cout << "Error opening szplt file. Path:" << endl;
+			cout << fuelf << endl;
+			exit(-1);
+		}
+
+		// Check how many frames are in the fuel file.
+		cout << "Checking Fuel file..." << endl;
+		CheckContents(fuelHandle,svar,fuelFrames,fuelTime);
+
+		if (svar.Bcase !=0)
+		{
+			string boundf = svar.output_prefix;
+			boundf.append("_boundary.szplt");
+
+			if(tecFileReaderOpen(boundf.c_str(),&boundHandle))
+			{
+				cout << "Error opening szplt file. Path:" << endl;
+				cout << boundf << endl;
+				exit(-1);
+			}
+
+			cout << "Checking Boundary file..." << endl;
+			CheckContents(boundHandle,svar,boundFrames,boundTime);
+
+			if(fuelFrames!= boundFrames)
+			{
+				cout << "Caution! Number of frames is not consistent between fuel and boundary files." << endl;
+			}
+
+			if(fuelTime != boundTime)
+			{
+				cout << "Caution! Frame times are not consistent between fuel and boundary files." << endl;
+
+				if(fuelTime > boundTime)
+				{
+					double time = 0.0;
+					for(int32_t frame = fuelFrames-1; frame > 1; frame--)
+					{
+						if(tecZoneGetSolutionTime(fuelHandle, frame, &time))
+						{
+							cout << "Failed to get time data for frame : " << frame << " from fuel file." << endl;
+							continue;
+						}
+						
+						if(time == boundTime)
+						{
+							cout << "Found the correct frame" << endl;
+							fuelFrames = frame;
+							fuelTime = time;
+							break;
+						}
+					}
+				}
+				else
+				{
+					double time = 0.0;
+					for(int32_t frame = boundFrames-1; frame >= 1; frame--)
+					{
+						if(tecZoneGetSolutionTime(boundHandle, frame, &time))
+						{
+							cout << "Failed to get time data for frame : " << frame << " from boundary file." << endl;
+							continue;
+						}
+						
+
+						if(time == fuelTime)
+						{
+							cout << "Found the correct frame" << endl;
+							boundFrames = frame;
+							boundTime = time;
+							break;
+						}
+					}
+				}
+
+				if(fuelTime != boundTime)
+				{
+					cout << "Could not find a consistent time in each file. Stopping." << endl;
+					exit(-1);
+				}
+			}
+
+			cout << "Attempting to read the boundary..." << endl;
+			Read_Binary_Timestep(boundHandle,svar,boundFrames,boundary);
+		}
+
+	    svar.frame = fuelFrames-1;
+
+	    // Read the actual data.
+		cout  << "Attempting to read the fuel..." << endl;
+		Read_Binary_Timestep(fuelHandle,svar,fuelFrames,fuel);
+
+
+		pn = boundary;
+		svar.bndPts = boundary.size();
+		svar.simPts = fuel.size();
+		pn.insert(pn.end(),fuel.begin(),fuel.end());	
+		svar.totPts = pn.size();
+		
+		if(svar.simPts + svar.bndPts != svar.totPts)
+		{
+			cout << "Mismatch of array sizes. Total array is not the sum of sim and boundary arrays" << endl;
+			exit(-1);
+		}
+
+		// Check the frame timings to ensure dt does not go negative.
+		// double frametime = svar.framet * real(fuelFrames-1);
+
+		// if(svar.t > frametime)
+		// {
+		// 	// There's a problem with the frame times.
+		// 	cout << "Time is further ahead than what is supposed by the frame timings." << endl;
+		// 	cout << "Need to adjust frame time to match the current time" << endl;
+
+		// 	// real framet = svar.t/real(fuelFrames-1.0);
+		// 	// cout << "Old frame time: " << svar.framet << "  New frame time: " << framet << endl << endl;
+		// 	// svar.framet = framet;			
+		// }
+
+		// if(svar.totPts != totPts || svar.bndPts != bndPts || svar.simPts != simPts)
+		// {
+		// 	cout << "Mismatch of the particle numbers in the frame file and data file." << endl;
+		// }
+	}
+	else
+	{
+		// TODO: ASCII Restart.
+		// Particle numbers can be found from frame file.
+		// Find EOF, then walk back from there how many particles.
+
+		cout << "ASCII file restart not yet implemented." << endl;
+		exit(-1);
+	}
+
+	// Go through the particles giving them the properties of the cell
+	size_t pID = 0;
+	vector<size_t> buffer;
+	#pragma omp parallel for 
+	for(size_t ii = 0; ii < svar.totPts; ++ii)
+	{
+		pn[ii].xi *= svar.scale;
+		
+		/* Set density based on pressure. More information this way */
+		pn[ii].rho = std::max(fvar.rhoMin,std::min(fvar.rhoMax, 
+			density_equation(pn[ii].p, fvar.B, fvar.gam, fvar.Cs, fvar.rho0)));
+
+		if(pn[ii].b == BACK)
+		{
+			#pragma omp critical
+			svar.back.emplace_back(ii);
+		}
+		else if(pn[ii].b == BUFFER)
+		{
+			#pragma omp critical
+			buffer.emplace_back(ii);
+		}
+
+		if(svar.Asource == 0)
+		{
+			pn[ii].cellRho = avar.rhog;
+			pn[ii].cellP = avar.pRef;
+		}
+		
+		// Initialise the rest of the values to 0
+		pn[ii].s = 0.0;
+		pn[ii].woccl = 0.0;
+		pn[ii].pDist = 0.0;
+		pn[ii].internal = 0;
+
+		pn[ii].vPert = StateVecD::Zero();
+
+		#pragma omp critical
+		{
+			if(pn[ii].partID > pID)
+				pID = pn[ii].partID;
+		}
+	}	
+
+	svar.partID = pID+1;
+
+	/* Put the particles into the buffer vector */
+	size_t const nBack = svar.back.size();
+	size_t const nBuffer = buffer.size();
+
+	if(nBuffer != 4*nBack)
+	{
+		cout << "Mismatch of back vector size and buffer vector size" << endl;
+		cout << "Buffer vector should be 4x back vector size." << endl;
+		cout << "Sizes are:  Buffer: " << nBuffer << "  Back: " << nBack << endl;
+		exit(-1);
+	}
+
+	std::sort(svar.back.begin(),svar.back.end());
+	std::sort(buffer.begin(),buffer.end());
+	svar.buffer = vector<vector<size_t>>(nBack,vector<size_t>(4));
+	real eps = 0.01*svar.dx; /* Tolerance value */
+	size_t nFound = 0;
+	for(size_t ii = 0; ii < nBack; ++ii)
+	{
+		StateVecD const test = svar.Transp*(pn[svar.back[ii]].xi-svar.sim_start);
+		
+		for(size_t index = 0; index < nBuffer; ++index)
+		{
+			/* Check which particle in the back vector it corresponds to by checking which  */
+			/* particle it lies behind */
+			StateVecD const xi = svar.Transp*(pn[buffer[index]].xi-svar.sim_start);
+			// cout << test[0] << "  " << test[1] << "  " << xi[0] << "  " << xi[1] << endl;
+
+			#if SIMDIM == 3
+			if(xi[2] < test[2] + eps && xi[2] > test[2] - eps)
+			{ /* Z coordinate is within bounds, now check x */
+			#endif
+			if(xi[0] < test[0] + eps && xi[0] > test[0] - eps)
+			{	/* X coordinate is within bounds, so should lie behind this point */
+
+				/* Start with the furthest away, and go closer */
+				if (xi[1] < test[1] - 4.0*svar.dx + eps)
+				{
+					svar.buffer[ii][3] = buffer[index];
+					nFound++;
+				}
+				else if (xi[1] < test[1] - 3.0*svar.dx + eps)
+				{
+					svar.buffer[ii][2] = buffer[index];
+					nFound++;
+				}
+				else if (xi[1] < test[1] - 2.0*svar.dx + eps)
+				{
+					svar.buffer[ii][1] = buffer[index];
+					nFound++;
+				}
+				else if (xi[1] < test[1] - svar.dx + eps)
+				{
+					svar.buffer[ii][0] = buffer[index];
+					nFound++;
+				}
+				else
+				{
+					cout << "Couldn't identify where to place the buffer particle" << endl;
+					exit(-1);
+				}
+			}
+			#if SIMDIM == 3
+			}
+			#endif
+		}
+	}	
+
+	if(nFound != nBuffer)
+	{
+		cout << "Some buffer particles have not been attached to a back particle. Cannot continue" << endl;
+		cout << nFound << "  " << nBuffer << endl;
+		exit(-1);
+	}
+	
+	pnp1 = pn;
 }
 
 #endif

--- a/src/Droplet.h
+++ b/src/Droplet.h
@@ -1,0 +1,536 @@
+#ifndef DROPLET_H
+#define DROPLET_H
+/* Library to perform drag assessment for a range of particle resolutions */
+#include "Var.h"
+#include "Shifting.h"
+#include "Neighbours.h"
+#include "Aero.h"
+#include "Add.h"
+
+
+/*Sphere-Plate interpolation method - Gissler et al (2017)*/
+inline void const Droplet_GisslerForce(AERO const& avar, StateVecD const& Vdiff, StateVecD const& norm, 
+						real const& rho, real const& press, real const& mass, real const& lam, real const& woccl,
+                        StateVecD& totAcc, StateVecD& sphereAcc, StateVecD& plateAcc)
+{
+	// real const nfull = avar.nfull;
+	real const Re = 2*rho*Vdiff.norm()*avar.L/avar.mug;
+	
+	real const frac2 = std::min(1.5 * lam, 1.0);
+	real const frac1 = (1.0 - frac2);
+
+ 	real const Cds  = GetCd(Re);
+
+	real Cdl, Adrop;
+	
+	#if SIMDIM == 3 
+		if(avar.useDef)
+		{
+			real ymax = Vdiff.squaredNorm()*avar.ycoef;
+			if (ymax > 1.0)
+				ymax = 1.0;
+			Cdl = Cds*(1+2.632*ymax);
+			Adrop = M_PI*pow((avar.L + avar.Cb*avar.L*ymax),2);
+		}
+		else
+		{
+			Cdl = Cds;
+			Adrop = avar.aSphere;
+		}
+	#else
+		if(avar.useDef)
+		{
+			real ymax = Vdiff.squaredNorm()*avar.ycoef;
+			if (ymax > 1.0)
+				ymax = 1.0;
+			 Cdl = Cds*(1+2.632*ymax);
+			Adrop = avar.aSphere + 2*(avar.Cb*avar.L*ymax) /** pow(avar.L,1)*/;
+		}
+		else
+		{
+			Cdl = Cds;
+			Adrop = avar.aSphere;
+		}
+	#endif
+
+	real const Cdi = frac1*Cdl + /* 0.5* */ /*1.37**/frac2;
+	real const Aunocc = (frac1*Adrop + frac2*avar.aPlate);
+
+	real const Ai = (1.0 - woccl)*Aunocc;
+
+	// cout << "Fractions: " << frac1 << "  " << frac2 << endl;
+	// cout << "Areas: " << Ai << "  " << Adrop << "  " << avar.aPlate << endl;
+	// cout << "Re: " << Re << "  Cds: " << Cdi << "  "  << Cdl << "  " << Cds  << endl;
+	// cout << "F: " << F(0) << "  " << F(1) << endl << endl;
+
+	StateVecD const q = 0.5 * Vdiff.norm() * Vdiff * avar.isossqr;
+	totAcc = q * avar.gamma * press * Cdi * Ai / mass;
+			 
+    sphereAcc = (1.0 - woccl) * frac1 * q *
+			 avar.gamma * press * Cdl * Adrop / mass;
+    
+    plateAcc = (1.0 - woccl) * frac2 * q *
+			 avar.gamma * press * avar.aPlate / mass; /* Cd of plate assumed to be 1 */
+
+}
+
+inline void const Droplet_InducedPressure(AERO const& avar, StateVecD const& Vdiff,
+        StateVecD const& norm, real const& Pbasei, real const& lam, SPHPart const& pi,
+        StateVecD& totAcc, StateVecD& sphereAcc, StateVecD& plateAcc)
+{
+	real theta = abs(acos(-norm.normalized().dot(Vdiff.normalized())));
+		
+	real Cp_p = 0.0;
+	real Cp_s = 0.0;
+	real Cp_tot = 0.0;
+
+	/*Spherical Cp*/
+	if(theta < 2.4455)
+	{
+		Cp_s = 1.0 - (2.25) * pow(sin(theta),2.0);
+	}
+	else
+	{
+		Cp_s = 0.075;
+	}
+
+	/*Plate Cp*/
+	if(theta < 1.570797)
+	{
+		Cp_p = cos(theta);
+	}
+	else if (theta < 1.9918)
+	{
+		Cp_p = -pow(cos(6.0*theta+0.5*M_PI),1.5);
+	}
+	else if (theta < 2.0838)
+	{
+		Cp_p = 5.5836*theta-11.5601;
+	}
+	else
+	{
+		Cp_p = 0.075;
+	}
+
+	/* Overall Cp (Ideal to machine learn at some point) */
+	if(pi.curve > 200.0)
+	{
+		if(theta < 1.570796)
+			Cp_tot = 0.5*cos(2.0*theta)+0.5;
+		else
+			Cp_tot = 0.0;
+	}
+	else if (pi.curve > 0.0)
+	{
+		real const frac = (pi.curve)/(200.0);
+		Cp_tot = frac + (1.0-frac)*Cp_p;
+	}
+	else if (pi.curve > -200.0)
+	{
+		real const frac = (pi.curve + 200.0)/(200.0);
+		Cp_tot = frac*Cp_p + (1.0-frac)*Cp_s;
+	}
+	else
+	{
+		Cp_tot = Cp_s;
+	}
+
+	/* Compressible dynamic pressure */
+	real const Plocali = 0.5*Vdiff.squaredNorm() * avar.isossqr * avar.gamma * pi.cellP * Cp_tot;
+	// cout << Plocalj << endl;
+
+	real const Pi = (Plocali/* +Pbasei */);
+	
+	// #pragma omp critical
+	// cout << Cp_s << "  " << Cp_p << "  " << Cp_tot << "  " << theta << "  " << pi.curve << "  " << Pi <<  endl;
+
+	real const Re = 2*pi.cellRho*Vdiff.norm()*avar.L/avar.mug;
+	real const Cdi  = GetCd(Re);
+
+	/* Pure droplet force */
+	StateVecD const acc_drop = 0.5*Vdiff*Vdiff.norm() * avar.isossqr * avar.gamma * pi.cellP
+					* avar.aSphere * Cdi/pi.m;
+	// aeroD = -Pi * avar.aPlate * norm[ii].normalized();
+
+	/* Induce pressure force */
+	StateVecD const acc_kern =  -/*0.5 **/ Pi * avar.aPlate * norm.normalized()/pi.m;
+	// StateVecD const F_kern = -(Pi/(pi.rho)) * norm;
+
+	/*Next, consider a skin friction force acting parallel to the surface*/
+	real const Vnorm = Vdiff.dot(norm.normalized());
+	StateVecD const Vpar = Vdiff - Vnorm*norm.normalized();
+
+	real const Re_par = 2.0*pi.cellRho*Vpar.norm()*avar.L/avar.mug;
+	real const Cf = 0.027/pow(Re_par+1e-6,1.0/7.0); /*Prandtl seventh power law for turbulent BL*/
+	// real const Cf = 0;
+
+	// StateVecD const acc_skin = StateVecD::Zero();
+	// StateVecD const acc_skin = 0.5*avar.rhog* Vpar.norm() * Cf * avar.aPlate * Vpar/pi.m;
+	StateVecD const acc_skin = 0.5 * Vpar.norm() * 	Vpar / (avar.sos*avar.sos) *
+			 avar.gamma * pi.cellP * Cf * avar.aPlate / pi.m;
+
+	real const frac1 = std::min(1.5 * lam, 1.0);
+	// real const frac2 = std::min(exp(pi.curve*0.001+200),1.0);
+
+
+	totAcc = (frac1 * /*frac2**/ (acc_kern+acc_skin) + (1.0-frac1) * acc_drop);
+    sphereAcc = (1.0-frac1)*acc_drop;
+    plateAcc = (frac1 * /*frac2**/ (acc_kern/* +acc_skin */));
+}
+
+
+void Droplet_Drag_Sweep(SIM& svar, FLUID& fvar, AERO& avar)
+{
+	cout << "Droplet drag sweet selected. Beginning sweep..." << endl;
+	vector<int> new_res;
+	/* Check if velocities or Reynolds have been defined */
+	if(svar.Reynolds.empty())
+	{
+		if(svar.velocities.empty())
+		{
+			cout << "ERROR: No Reynolds or velocities have been defined for the sweep. Stopping. " << endl;
+			exit(-1);
+		}
+		else
+		{
+			for(real const& vel:svar.velocities)
+			{
+				real const Re = avar.rhog*vel*svar.diam/avar.mug;
+				svar.Reynolds.emplace_back(Re);
+			}
+		}
+	}
+
+	if(svar.nacross.empty())
+	{
+		if(svar.diameters.empty())
+		{
+			cout << "ERROR: No resolutions have been defined for the sweep. Stopping. " << endl;
+			exit(-1);
+		}
+		else
+		{
+			for(real const& diam : svar.diameters)
+			{
+				if(svar.diam/diam < 1.5)
+				{
+					new_res.emplace_back(1);
+					svar.nacross.emplace_back(1);
+				}
+				else
+				{
+					real radius = 0.5*svar.diam;
+					int nrad = ceil(radius/diam);
+					svar.nacross.emplace_back(2*nrad+1);
+					new_res.emplace_back(2*nrad + 1);
+				}
+			}
+		}
+	}
+	else
+	{
+		for(int const& res : svar.nacross)
+		{
+			if(res == 1)
+			{
+				new_res.emplace_back(1);
+			}
+			else
+			{
+				real radius = 0.5*svar.diam;
+				real dx = radius/real(0.5*(res-1));
+				int nrad = ceil(radius/dx);
+				new_res.emplace_back(2*nrad + 1);
+			}
+		}
+	}
+
+    /* Level 1 = resolution, level 2 = Reynolds, level 3 = different drag values */
+    vector<vector<vector<real>>> drop_data(
+		svar.nacross.size(),vector<vector<real>>(svar.Reynolds.size(),vector<real>(6,0.0)));
+
+    MESH cells;
+
+    if(cells.cCentre.size() == 0)
+        cells.cCentre.emplace_back(StateVecD::Zero());
+
+    if(cells.fNum.size() == 0)
+    {
+        cells.fNum.emplace_back();
+        cells.fMass.emplace_back();
+        cells.vFn.emplace_back();
+        cells.vFnp1.emplace_back();
+        cells.cVol.emplace_back();
+        cells.cMass.emplace_back();
+        cells.cRho.emplace_back();
+        cells.cPertn.emplace_back();
+        cells.cPertnp1.emplace_back();
+    }
+
+    for(size_t res_i = 0; res_i < svar.nacross.size(); ++res_i)
+    {
+		size_t const& res =  svar.nacross[res_i];
+
+        drop_data.emplace_back();
+        /* Create the droplet */
+        SPHState pn;
+        DELTAP dp;
+        OUTL outlist;
+        
+		svar.simPts = 0;
+		svar.totPts = 0;
+        
+        if(res == 1)
+		{	/*spacing is too close to full size to use standard adjustment*/
+			svar.nrad = 1;
+			svar.dx = svar.diam;
+			svar.Pstep = svar.diam;
+			fvar.simM = fvar.rho0*pow(svar.Pstep,SIMDIM); 
+			StateVecD xi = StateVecD::Zero();
+			StateVecD v = StateVecD::Zero();
+			real rho = fvar.rho0;
+			real press = 0;
+			size_t pID = 0;
+			pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,FREE,pID));
+			svar.simPts=1;
+			svar.totPts=1;
+		}
+		else
+		{
+			real radius = 0.5*svar.diam;
+			svar.dx = radius/real(0.5*(res-1));
+			int nrad = ceil(radius/svar.dx);
+			svar.dx = radius / real(nrad);
+			
+			svar.Pstep = svar.dx;
+			
+			fvar.simM = fvar.rho0*pow(svar.Pstep,SIMDIM); 
+
+			// #if SIMDIM == 2
+			// CreateRDroplet(svar,fvar,pn);
+			// #else
+			CreateDroplet(svar,fvar,pn);
+			// #endif
+		}
+
+		/* Set the SPH parameters for the new size */
+		fvar.H = fvar.Hfac*svar.Pstep;
+		fvar.HSQ = fvar.H*fvar.H; 
+		fvar.sr = 4*fvar.HSQ; 	/*KDtree search radius*/
+
+		#if SIMDIM == 2
+			#ifdef CUBIC
+				fvar.correc = 10.0 / (7.0 * M_PI * fvar.H * fvar.H);
+			#else
+				fvar.correc = 7.0 / (4.0 * M_PI * fvar.H * fvar.H);
+			#endif
+		#endif
+		#if SIMDIM == 3
+			#ifdef CUBIC
+				fvar.correc = (1.0/(M_PI*fvar.H*fvar.H*fvar.H));
+			#else
+				fvar.correc = (21/(16*M_PI*fvar.H*fvar.H*fvar.H));
+			#endif
+		#endif
+
+		avar.GetYcoef(fvar, /* fvar.H */ svar.Pstep);
+
+		
+        cout << endl << "Original resolution: " << res<< " Actual resolution: " << 
+			new_res[res_i] << "  Particle count: " << svar.simPts << endl;
+		
+		// real tot_mass = fvar.simM * svar.simPts;
+
+        ///********* Tree algorithm stuff ************/
+        KDTREE TREE(pn,cells);
+        
+        TREE.NP1.index->buildIndex();
+        FindNeighbours(TREE.NP1, fvar, pn, outlist);
+
+        dSPH_PreStep(fvar,pn.size(),pn,outlist,dp);
+        Detect_Surface(svar,fvar,avar,0,pn.size(),dp,outlist,cells,pn);
+
+        /* Remove particles that aren't going to receive a force */
+        SPHState to_test;
+		vector<StateVecD> norm;
+		vector<real> lam;
+		#pragma omp parallel default(shared)/* shared(leftright) */
+		{
+			SPHState local;
+			vector<StateVecD> norm_l;
+			vector<real> lam_l;
+			#pragma omp for schedule(static) nowait
+			for(size_t ii = 0; ii < pn.size(); ++ii)
+			{
+				if( dp.lam_ng[ii] < avar.cutoff )
+				{
+					local.emplace_back(pn[ii]);
+					norm_l.emplace_back(dp.norm[ii]);
+					lam_l.emplace_back(dp.lam_ng[ii]);
+				}
+			}
+
+			#pragma omp for schedule(static) ordered
+			for(int ii = 0; ii < omp_get_num_threads(); ++ii)
+			{
+				#pragma omp ordered
+				{
+					to_test.insert(to_test.end(),local.begin(),local.end());
+					norm.insert(norm.end(),norm_l.begin(),norm_l.end());
+					lam.insert(lam.end(),lam_l.begin(),lam_l.end());
+				}
+			}
+		}
+
+		cout << "Test size: " << to_test.size() << endl;
+
+        for(size_t Re_i = 0; Re_i < svar.Reynolds.size(); ++Re_i)
+        {
+			real const& Re =  svar.Reynolds[Re_i];
+			real const vel = (avar.mug*Re)/(avar.rhog*svar.diam);
+            StateVecD tAcc_g = StateVecD::Zero();
+            StateVecD sAcc_g = StateVecD::Zero();
+            StateVecD pAcc_g = StateVecD::Zero();
+            StateVecD tAcc_ip = StateVecD::Zero();
+            StateVecD sAcc_ip = StateVecD::Zero();
+            StateVecD pAcc_ip = StateVecD::Zero();
+			cout << "Calculating drag for Reynolds: " << Re;
+
+            // #pragma omp parallel for
+            for(size_t ii = 0; ii < to_test.size(); ++ii)
+            {
+                SPHPart& pi = to_test[ii];
+                // pi.cellV[1] = vel;
+                pi.cellP = avar.pRef;
+				pi.cellRho = avar.rhog;
+
+                StateVecD Vdiff = StateVecD::Zero();
+                Vdiff[1] = vel;
+				
+                StateVecD totalAcc_g, sphereAcc_g, plateAcc_g, totalAcc_ip, sphereAcc_ip, plateAcc_ip;
+
+                
+				/* Original Gissler */
+				Droplet_GisslerForce(avar,Vdiff,norm[ii],avar.rhog,avar.pRef,pi.m,lam[ii],pi.woccl,
+					totalAcc_g,sphereAcc_g,plateAcc_g);
+			
+			
+				/* Induced pressure based model */	
+				Droplet_InducedPressure(avar,Vdiff,norm[ii],0.0,lam[ii],pi, 
+						totalAcc_ip, sphereAcc_ip, plateAcc_ip);
+                
+
+                tAcc_g += totalAcc_g * pi.m;
+                sAcc_g += sphereAcc_g * pi.m;
+                pAcc_g += plateAcc_g * pi.m;
+				tAcc_ip += totalAcc_ip * pi.m;
+                sAcc_ip += sphereAcc_ip * pi.m;
+                pAcc_ip += plateAcc_ip * pi.m;
+            }
+
+			// real dynp = 0.5*(tot_mass/(M_PI*0.25*svar.diam*svar.diam))*vel*vel*svar.diam;
+			// real dynp = 1.0;
+			#if SIMDIM == 3
+			real dynp = 0.5 * (vel*vel/(avar.sos*avar.sos)) * avar.gamma * avar.pRef * 0.25 * M_PI * svar.diam * svar.diam;
+			#else
+			real dynp = 0.5 * (vel*vel/(avar.sos*avar.sos)) * avar.gamma * avar.pRef * svar.diam;
+			#endif
+
+            drop_data[res_i][Re_i][0] = tAcc_g[1]/dynp;
+			drop_data[res_i][Re_i][1] = sAcc_g[1]/dynp;
+			drop_data[res_i][Re_i][2] = pAcc_g[1]/dynp;
+			drop_data[res_i][Re_i][3] = tAcc_ip[1]/dynp;
+			drop_data[res_i][Re_i][4] = sAcc_ip[1]/dynp;
+			drop_data[res_i][Re_i][5] = pAcc_ip[1]/dynp;
+
+			cout << "    Gissler: " << drop_data[res_i][Re_i][0] << "  Induced Pressure: " << drop_data[res_i][Re_i][3] << endl;
+        }
+		cout << "Resolutions remaining: " << svar.nacross.size() - res_i - 1 << endl;
+    }
+
+    /* Write data to file */
+    std::ofstream fout("Droplet_Sweep.dat",std::ios::out);
+
+    fout << "VARIABLES = \"diameter resolution\", \"Gissler normalised drag\"," <<
+        "\"Gissler total drag\", \"Gissler sphere drag\", \"Gissler plate drag\"" << 
+		"\"Induced pressure normalised drag\", " << 
+		"\"Induced pressure total drag\", \"Induced pressure sphere drag \", \"Induced pressure plate drag\"" << endl; 
+
+    for(size_t ii = 0; ii < svar.Reynolds.size(); ++ii)
+    {
+		/* Drag for the full droplet */
+        real const Re = svar.Reynolds[ii];
+        real const big_cd = GetCd(Re);
+
+        fout << "ZONE T=\"Re = " << std::to_string(Re) << "\"" << endl;
+        for(size_t jj = 0; jj < svar.nacross.size(); ++jj)
+        {
+            real drag_g = (drop_data[jj][ii][0])/big_cd;
+			real drag_ip = (drop_data[jj][ii][3])/big_cd  ;
+			// real drag_g = (drop_data[jj][ii][0])/big_drag;
+			// real drag_ip = (drop_data[jj][ii][3])/big_drag;
+            fout << new_res[jj] << " " << drag_g << " " << drop_data[jj][ii][0] << " " << drop_data[jj][ii][1] << " " << drop_data[jj][ii][2] <<
+				" " << drag_ip << " " << drop_data[jj][ii][3] << " " << drop_data[jj][ii][4] << " " << drop_data[jj][ii][5] << endl;
+        }
+		
+		/* Ideal line curve */
+		fout << "ZONE T=\"Re = " << std::to_string(Re) << " Idealised\"" << endl;
+		for(size_t jj = 0; jj < svar.nacross.size(); ++jj)
+		{
+			fout << new_res[jj] << " 1 " << big_cd << " " << big_cd << " " << big_cd << 
+						   " 1 " << big_cd << " " << big_cd << " " << big_cd << endl;
+			// fout << res << " 1 " << big_drag << " " << big_drag << " " << big_drag << 
+			// 			   " 1 " << big_drag << " " << big_drag << " " << big_drag << endl;
+		}
+    }
+
+    fout.close();
+
+
+    /* Write data to file */
+    std::ofstream fout2("Droplet_Sweep_Transpose.dat",std::ios::out);
+
+    fout2 << "VARIABLES = \"Reynolds\", \"Gissler normalised drag\"," <<
+        "\"Gissler total drag\", \"Gissler sphere drag\", \"Gissler plate drag\"" << 
+		"\"Induced pressure normalised drag\", " << 
+		"\"Induced pressure total drag\", \"Induced pressure sphere drag \", \"Induced pressure plate drag\"" << endl; 
+
+    for(size_t jj = 0; jj < svar.nacross.size(); ++jj)
+    {
+        fout2 << "ZONE T=\"Resolution = " << std::to_string(new_res[jj]) << "\"" << endl;
+        for(size_t ii = 0; ii < svar.velocities.size(); ++ii)
+        {
+			real const vel = svar.velocities[ii];
+			/* Drag for the full droplet */
+			real const Re = avar.rhog*vel*svar.diam/avar.mug;
+			real const big_cd = GetCd(Re);
+			
+            real drag_g = (drop_data[jj][ii][0] - big_cd)/big_cd + 1;
+			real drag_ip = (drop_data[jj][ii][3] - big_cd)/big_cd + 1 ;
+			// real drag_g = (drop_data[jj][ii][0] - big_drag)/big_drag;
+			// real drag_ip = (drop_data[jj][ii][3] - big_drag)/big_drag;
+            fout2 << Re << " " << drag_g << " " << drop_data[jj][ii][0] << " " << drop_data[jj][ii][1] << " " << drop_data[jj][ii][2] <<
+				" " << drag_ip << " " << drop_data[jj][ii][3] << " " << drop_data[jj][ii][4] << " " << drop_data[jj][ii][5] << endl;
+        }
+		
+		
+    }
+
+	/* Ideal line curve */
+	fout2 << "ZONE T=\"Idealised\"" << endl;
+	for(size_t ii = 0; ii < svar.velocities.size(); ++ii)
+	{
+		real const vel = svar.velocities[ii];
+		/* Drag for the full droplet */
+		real const Re = avar.rhog*vel*svar.diam/avar.mug;
+
+		// real res = svar.diam/svar.dx;
+		fout2 << Re << " 1 " << "1" << " " << "1" << " " << "1" << 
+						" 1 " << "1" << " " << "1" << " " << "1" << endl;
+	}
+
+    fout2.close();
+}
+
+
+#endif

--- a/src/FOAMIO.h
+++ b/src/FOAMIO.h
@@ -617,7 +617,7 @@ namespace FOAM
         /* Find cell centres  */
         cout << "Finding cell centres..." << endl;
         vector<StateVecD> cCentre(nCells);
-        vector<vector<size_t>> elems(nCells);
+        // vector<vector<size_t>> elems(nCells);
         for(size_t ii = 0; ii < nCells; ++ii)
         {
             vector<size_t> verts;
@@ -639,7 +639,7 @@ namespace FOAM
             }
             sum /= verts.size();
             cCentre[ii] = sum;
-            elems[ii] = verts;
+            // elems[ii] = verts;
         }
 
         cout << "Placing data in cell structure..." << endl;
@@ -649,7 +649,7 @@ namespace FOAM
         cells.faces = faces; /* Face data */
         cells.leftright = leftright; 
 
-        cells.elems = elems; /* Cell data */
+        // cells.elems = elems; /* Cell data */
         cells.cCentre = cCentre;
         cells.cFaces = cFaces;
 

--- a/src/IO.h
+++ b/src/IO.h
@@ -7,7 +7,8 @@
 #include "Third_Party/Eigen/LU"
 #include "Var.h"
 #include "IOFunctions.h"
-#include "CDFIO.h"
+#include "BinaryIO.h"
+#include "Geometry.h"
 #include <ctime>
 // #include "Restart.h"
 // #include "TauIO.h"
@@ -29,10 +30,14 @@ void Set_Values(SIM& svar, FLUID& fvar, AERO& avar)
 		avar.vStart = svar.Rotate*avar.vStart;
 	}
 
-	fvar.B = fvar.rho0*pow(fvar.Cs,2)/fvar.gam;  /*Factor for Tait's Eq*/
+	fvar.B = fvar.rho0*pow(fvar.Cs,2)/fvar.gam;  /*Factor for Cole's Eq*/
 
 	/*Pipe Pressure calc*/
-	fvar.rhoJ = fvar.rho0*pow((fvar.pPress/fvar.B) + 1.0, 1.0/fvar.gam);
+	fvar.rhoJ = density_equation(fvar.pPress,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
+	
+	/* Upper and lower limits for density */
+	fvar.rhoMax = fvar.rho0*(1.0 + fvar.rhoVar*0.01);
+	fvar.rhoMin = fvar.rho0*(1.0 - fvar.rhoVar*0.01);
 
 	svar.nrad = 1;
 	if(svar.Scase == 1)
@@ -87,8 +92,6 @@ void Set_Values(SIM& svar, FLUID& fvar, AERO& avar)
 	// svar.dx = svar.Pstep;	
 	svar.Pstep = svar.dx * pow(fvar.rhoJ/fvar.rho0,1.0/SIMDIM);
  	
-  	
-
 	// Correct the droplet to have the same volume as the original
 	if(svar.Scase == 3)
 	{
@@ -108,11 +111,30 @@ void Set_Values(SIM& svar, FLUID& fvar, AERO& avar)
 	fvar.simM = fvar.rho0*pow(svar.Pstep,SIMDIM); 
 	fvar.bndM = fvar.simM;
 	avar.gasM = avar.rhog*pow(svar.Pstep,SIMDIM);
-	avar.qInf = 0.5*avar.rhog*avar.vRef*avar.vRef;
+
+	avar.sos = sqrt(avar.T*avar.Rgas*avar.gamma);
+	avar.isossqr = 1.0/(avar.sos*avar.sos);
+	
+	if(avar.MRef != -1)
+	{
+		/* Mach has been defined, not velocity */
+		avar.vRef = avar.sos * avar.MRef;
+	}
+	else
+	{
+		avar.MRef = avar.vRef/avar.sos;
+	}
+		
+	avar.qInf = 0.5*avar.MRef*avar.MRef*avar.gamma*avar.pRef;
 
 	svar.addcount = 0;
-  	svar.dt = 2E-010; 			/*Initial timestep*/
-  	fvar.H = 2.0*svar.Pstep;
+	
+	if(svar.dt_min > 0)
+		svar.dt = svar.dt_min;
+	else
+		svar.dt = 2E-010; 			/*Initial timestep*/
+
+  	fvar.H = fvar.Hfac*svar.Pstep;
   	fvar.HSQ = fvar.H*fvar.H; 
 	fvar.sr = 4*fvar.HSQ; 	/*KDtree search radius*/
 
@@ -145,17 +167,18 @@ void Set_Values(SIM& svar, FLUID& fvar, AERO& avar)
 		#endif
 	#endif
 		
-		fvar.Wdx = Kernel(svar.Pstep,fvar.H,fvar.correc);
+	fvar.Wdx = Kernel(svar.Pstep,fvar.H,fvar.correc);
 
 	#if SIMDIM == 3
 		if (svar.Asource == 3)
 		{
-			svar.vortex.Init(svar.infile);
+			svar.vortex.Init(svar.vlm_file);
 			svar.vortex.GetGamma(avar.vInf);
 		}
 	#endif
 
-		GetYcoef(avar, fvar, /*fvar.H*/ svar.Pstep);
+	avar.GetYcoef(fvar, /*fvar.H*/ svar.Pstep);
+
 	#if SIMDIM == 3
 		avar.aPlate = svar.Pstep * svar.Pstep;
 		// avar.aPlate = fvar.H*fvar.H;
@@ -222,6 +245,7 @@ void Print_Settings(char** argv, SIM const& svar, FLUID const& fvar, AERO const&
 	cout << endl;		
 	cout << "****** RESTING FUEL SETTINGS *******" << endl;
 	cout << "Resting density: " << fvar.rho0 << endl;
+	cout << "Maxmimum density variation: " << fvar.rhoVar << "\%" << endl;
 	cout << "Particle spacing: " << svar.Pstep << endl;
 	cout << "Support radius: " << fvar.H << endl;
 	cout << "Particle mass: " << fvar.simM << endl;
@@ -252,8 +276,6 @@ void Print_Settings(char** argv, SIM const& svar, FLUID const& fvar, AERO const&
 		cout << "Gas dynamic pressure: " << avar.qInf << endl << endl;
 	}
 	
-	
-
 	cout << "******** FILE SETTINGS ********" << endl;	
 	// cout << "Working directory: " << cCurrentPath << endl;
 	cout << "Input file: " << argv[1] << endl;
@@ -274,6 +296,7 @@ void Print_Settings(char** argv, SIM const& svar, FLUID const& fvar, AERO const&
 	cout << "Output prefix: " << svar.output_prefix << endl << endl;
 
 }
+
 
 void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 {
@@ -301,15 +324,15 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
     string line;
     while (getline(fin,line))
     {
-        line = ltrim(line);
-        if(line[0] == '#') /* Skip commented line */
-            continue;
+        size_t end = line.find_first_of('#');
+		if(end != std::string::npos)
+			line = line.substr(0,end+1);
 
         /* File Inputs */
         Get_String(line, "Primary grid face filename", svar.taumesh);
         Get_String(line, "Boundary mapping filename", svar.taubmap);
         Get_String(line, "Restart-data prefix", svar.tausol);
-        Get_String(line, "SPH restart-data prefix", svar.restart_prefix);
+        Get_String(line, "SPH restart prefix", svar.restart_prefix);
         Get_Number(line, "Grid scale", svar.scale);
         Get_Number(line, "2D offset vector (0 / x=1,y=2,z=3)",svar.offset_axis);
         Get_String(line, "OpenFOAM folder", svar.foamdir);
@@ -317,6 +340,9 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
         Get_Number(line, "OpenFOAM binary (0/1)", svar.isBinary);
         Get_Number(line, "Label size (32/64)", svar.labelSize);
         Get_Number(line, "Scalar size (32/64)", svar.scalarSize);
+		#if SIMDIM == 3
+		Get_String(line, "VLM definition filename", svar.vlm_file); 
+		#endif 
 
         /* File outputs */
 		Get_String(line, "Output files prefix", svar.output_prefix);
@@ -334,28 +360,38 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
         Get_Number(line, "Sutherland reference viscosity", avar.mug);
         Get_Number(line, "Reference dispersed viscosity", fvar.mu);
         Get_Number(line, "Reference surface tension", fvar.sig);
+		Get_Number(line, "SPH surface tension contact angle", fvar.contangb);
+        Get_Number(line, "Init hydrostatic pressure (0/1)", svar.init_hydro_pressure);
+		Get_Number(line, "Hydrostatic height", svar.hydro_height);
+
+		/* Aerodynamic data */
         Get_Number(line, "Reference velocity", avar.vRef);
         Get_Number(line, "Reference pressure", avar.pRef);
         Get_Number(line, "Reference Mach number", avar.MRef);
         Get_Number(line, "Reference density", avar.qInf);
         Get_Number(line, "Reference temperature", avar.T);
+		Get_Number(line, "Gas constant gamma", avar.gamma);
 
-		// Get_Number(line, "SPH surface tension contact angle", fvar.contangb);
-
-        /* Simulation settings */
+		/* Simulation settings */
+		Get_Number(line, "SPH boundary solver (0=pressure/1=ghost)", svar.bound_solver);
 		Get_Number(line, "SPH maximum timestep", svar.dt_max);
 		Get_Number(line, "SPH minimum timestep", svar.dt_min);
+        Get_Number(line, "SPH CFL condition", svar.cfl);
 		Get_Number(line, "SPH starting pressure", fvar.pPress);
-		Get_Number(line, "SPH speed of sound", fvar.Cs);
+		Get_Number(line, "SPH maximum density variation (%)", fvar.rhoVar);
 		Get_Number(line, "SPH artificial viscosity factor", fvar.alpha);
+		Get_Number(line, "SPH speed of sound", fvar.Cs);
         Get_Number(line, "SPH Newmark-Beta iteration limit", svar.subits);
         Get_Number(line, "SPH initial spacing", svar.Pstep);
         Get_Number(line, "SPH boundary spacing factor", svar.Bstep);
+        Get_Number(line, "SPH smoothing length factor", fvar.Hfac);
         Get_String(line, "SPH aerodynamic case", avar.aero_case);
+        Get_Number(line, "SPH use TAB deformation (0/1)", avar.useDef);
         Get_Number(line, "SPH use ghost particles (0/1)", svar.ghost);
         Get_Vector(line, "SPH start coordinates", svar.sim_start);
 		Get_Vector(line, "SPH boundary start coordinates", svar.bound_start);
 		Get_Number(line, "SPH maximum particle count",svar.finPts);
+        Get_Number(line, "SPH aerodynamic cutoff value", avar.cutoff);
 
         /* Starting area conditions */
         Get_String(line, "SPH start geometry type", svar.start_type);
@@ -372,12 +408,20 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
         Get_Vector(line, "SPH freestream velocity", avar.vInf);
 
         /* Particle tracking settings */
+		Get_Number(line, "Transition to IPT (0/1)", svar.using_ipt);
         Get_Number(line, "Velocity equation order (1/2)", svar.eqOrder);
         Get_Number(line, "SPH tracking conversion x coordinate", svar.max_x_sph);
         Get_Number(line, "Maximum x trajectory coordinate", svar.max_x);
-		Get_Number(line, "Particle scatter output (0/1)", svar.partout);
-        Get_Number(line, "Particle streak output (0/1)", svar.streakout);
-        Get_Number(line, "Particle cell intersection output (0/1)", svar.cellsout);
+		Get_Number(line, "Particle scatter output (0/1/2)", svar.partout);
+        Get_Number(line, "Particle streak output (0/1/2)", svar.streakout);
+        Get_Number(line, "Particle cell intersection output (0/1/2)", svar.cellsout);
+
+		/* Droplet drag sweep settings */
+		Get_Number(line, "Do droplet drag sweep (0/1)", svar.dropDragSweep);
+        Get_Array(line, "Droplet resolutions", svar.nacross);
+		Get_Array(line, "Droplet diameters", svar.diameters);
+		Get_Array(line, "Droplet velocities", svar.velocities);
+		Get_Array(line, "Droplet Reynolds numbers", svar.Reynolds);
     }
 
     fin.close();
@@ -389,7 +433,20 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 		
 		if(svar.foamdir.empty())
 		{
-			svar.Asource = 0;	
+			#if SIMDIM == 3
+			if(svar.vlm_file.empty())
+				svar.Asource = 0;
+			else
+			{
+				svar.Asource = 3;
+
+				if(svar.vlm_file == "(thisfile)")
+					svar.vlm_file = svar.infile;
+			}
+
+			#else
+			svar.Asource = 0;
+			#endif
 		}
 		else
 		{
@@ -412,6 +469,11 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 			cout << "Input TAU bmap file not defined." << endl;
 			exit(-1);
 		}
+		else if(svar.taubmap == "(thisfile)")
+		{
+			/* The para file is the boundary definition file, so set it so */
+			svar.taubmap = svar.infile;
+		}
 
 		if(svar.tausol.empty())
 		{
@@ -420,20 +482,7 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 		}
 
 	}
-
-	if(!svar.restart_prefix.empty())
-	{
-		svar.restart = 1;
-		Check_If_Restart_Possible(svar);
-		svar.output_prefix = svar.restart_prefix;
-	}
-
-	if(svar.Pstep < 0)
-	{
-		cout << "SPH initial spacing has not been defined." << endl;
-		exit(-1);
-	}
-
+	
 	/* Check starting geometry conditions */
 	if (svar.sim_start[0] == 999999 || svar.sim_start[1] == 999999
 		#if SIMDIM == 3
@@ -455,10 +504,18 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 			#endif
 			)
 		{
-			cout << "Some or all of the SPH box resolutions have not been defined." << endl;
-			exit(-1);
+			if(svar.Pstep < 0)
+			{
+				cout << "SPH box resolution or initial spacing has not been defined." << endl;
+				exit(-1);
+			}	
 		}
-
+		else
+		{
+			real dx = svar.sim_box[0]/svar.xyPART[0];
+			real dy = svar.sim_box[1]/svar.xyPART[1];
+			svar.Pstep = std::min(dx,dy);
+		}
 		
 	}
 	else if(svar.start_type == "cylinder")
@@ -519,7 +576,7 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 		svar.Bcase = 1;
 
 		if (svar.bound_start[0] == 999999 || svar.bound_start[1] == 999999
-#if SIMDIM == 3
+			#if SIMDIM == 3
 			|| svar.bound_start[2] == 999999
 			#endif
 		)
@@ -580,6 +637,30 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 		exit(-1);
 	}
 
+	if(svar.Bcase != 0)
+	{
+		if(svar.bound_solver > 1)
+		{
+			cout << "Boundary solver not defined correctly." << endl;
+			exit(-1);
+		}
+	}
+
+	/* Check for restart data now boundary case is known */	
+	if(!svar.restart_prefix.empty())
+	{
+		svar.restart = 1;
+		Check_If_Restart_Possible(svar);
+		svar.output_prefix = svar.restart_prefix;
+	}
+
+
+	if(svar.Pstep < 0)
+	{
+		cout << "SPH initial spacing has not been defined." << endl;
+		exit(-1);
+	}
+
 	if(svar.Nframe < 0)
 	{
 		cout << "Number of frames to output not defined." << endl;
@@ -590,6 +671,15 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 	{
 		cout << "Frame time interval has not been defined." << endl;
 		exit(-1);
+	}
+
+	if(svar.init_hydro_pressure)
+	{
+		if(svar.hydro_height < 0)
+		{
+			cout << "Hydrostatic height has not been defined." << endl;
+			exit(-1);
+		}
 	}
 
 	/* Aerodynamic settings */
@@ -619,44 +709,118 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
 	{
 		svar.dt = svar.dt_min;
 	}
+
+	if(svar.dropDragSweep)
+	{
+		if(svar.nacross.empty())
+		{
+			if(svar.diameters.empty())
+			{
+				cout << "" << endl;
+				exit(-1);
+			}
+			else
+			{
+				for(real const& dx : svar.diameters)
+				{
+					/* Droplet case */
+					if(svar.diam/dx < 1.5)
+					{	/*spacing is too close to full size to use standard adjustment*/
+						svar.nacross.emplace_back(1);
+					}
+					else
+					{
+						svar.nacross.emplace_back(ceil(abs(svar.diam/dx)));
+					}
+				}
+			}
+		}
+
+		fvar.pPress = 0;
+	}
+
 	/* Particle Tracking Settings */
-    // if(svar.partout == 1)
-    // {
-    //     if(svar.outdir.empty())
-    //     {
-    //         cout << "Output particle directory not defined." << endl;
-    //         exit(-1);
-    //     }
-    // }
+	if(svar.using_ipt)
+	{
+		// if(svar.partout == 1)
+		// {
+		//     // if(svar.outdir.empty())
+		//     // {
+		//     //     cout << "Output particle directory not defined." << endl;
+		//     //     exit(-1);
+		//     // }
+		// 	string partf = svar.output_prefix + "_parts.dat";
 
-    // if(svar.streakout == 1)
-    // {
-    //     if(svar.streakdir.empty())
-    //     {
-    //         cout << "Output particle streaks directory not defined." << endl;
-    //         exit(-1);
-    //     }
-    // }
+		// 	svar.partfile.open(partf,std::ios::out);
+		// 	if(!svar.cellfile)
+		// 	{
+		// 		cout << "Failed to open the particle tracking scatter file." << endl;
+		// 		exit(-1);
+		// 	}
+		// }
 
-    // if(svar.cellsout == 1)
-    // {
-    //     if(svar.celldir.empty())
-    //     {
-    //         cout << "Output cell intersections directory not defined." << endl;
-    //         exit(-1);
-    //     }
-    // }
+		// if(svar.streakout == 1)
+		// {
+		//     // if(svar.streakdir.empty())
+		//     // {
+		//     //     cout << "Output particle streaks directory not defined." << endl;
+		//     //     exit(-1);
+		//     // }
+		// 	string streakf = svar.output_prefix + "_streaks.dat";
+		// 	svar.streakfile.open(streakf,std::ios::out);
+		// 	if(!svar.cellfile)
+		// 	{
+		// 		cout << "Failed to open the particle tracking streaks file." << endl;
+		// 		exit(-1);
+		// 	}
+		// }
 
-    if(svar.eqOrder > 2 || svar.eqOrder < 1)
-    {
-        cout << "Equation order not 1 or 2. Please choose between these." << endl;
-        exit(-1);
-    }
+		// if(svar.cellsout == 1)
+		// {
+		//     // if(svar.celldir.empty())
+		//     // {
+		//     //     cout << "Output cell intersections directory not defined." << endl;
+		//     //     exit(-1);
+		//     // }
+		// 	string cellf = svar.output_prefix + "_cells.dat";
+		// 	svar.cellfile.open(cellf,std::ios::out);
+		// 	if(!svar.cellfile)
+		// 	{
+		// 		cout << "Failed to open the particle tracking cell file." << endl;
+		// 		exit(-1);
+		// 	}
+		// }
 
-    // svar.streakdir = svar.outfile;
-    // size_t pos = svar.streakfile.find_last_of(".");
-    // svar.streakfile.insert(pos,"_streak");
-    
+		if(svar.eqOrder > 2 || svar.eqOrder < 1)
+		{
+			cout << "Equation order not 1 or 2. Please choose between these." << endl;
+			exit(-1);
+		}
+
+		if(svar.max_x < svar.sim_start[0])
+		{
+			cout << "ERROR: Maximum x coordinate for particle tracking or SPH is less than the starting position." << endl;
+			exit(-1);
+		}
+
+		if(svar.max_x < svar.max_x_sph)
+		{
+			cout << "WARNING: Maximum x coordinate for particle tracking is less than that for SPH." << endl;
+			cout << "         No particle tracking will be performed." << endl;
+			svar.using_ipt = 0;
+		}
+
+		if(svar.max_x_sph < svar.sim_start[0])
+		{
+			cout << "WARNING: Maximum x coordinate for SPH particles is less than the starting position." << endl;
+			cout << "         Particles will immediately transition to tracking." << endl;
+		}
+
+		// svar.streakdir = svar.outfile;
+		// size_t pos = svar.streakfile.find_last_of(".");
+		// svar.streakfile.insert(pos,"_streak");
+	}
+	
     if(svar.offset_axis != 0)
     {
         if(SIMDIM != 2)
@@ -670,6 +834,14 @@ void GetInput(int argc, char **argv, SIM& svar, FLUID& fvar, AERO& avar)
         exit(-1);
     }
 
+	#if SIMDIM == 2
+	if(svar.offset_axis == 0)
+	{
+		cout << "ERROR: Offset axis has not been defined." << endl;
+		exit(-1);
+	}
+	#endif
+	
   	Set_Values(svar,fvar,avar);
 
 	Print_Settings(argv,svar,fvar,avar);
@@ -877,12 +1049,11 @@ void Write_ASCII_Timestep(std::fstream& fp, SIM& svar, SPHState const& pnp1,
 }
 
 void Write_First_Step(std::fstream& f1, std::fstream& fb, std::fstream& fg, 
-						SIM& svar, SPHState const& pnp1, SPHState const& airP)
+						SIM& svar, SPHState const& pnp1/* , SPHState const& airP */)
 {
 	if(svar.out_encoding == 1 )
 	{
 		/*Write sim particles*/
-		
 		Init_Binary_PLT(svar,"_fuel.szplt","Simulation Particles",svar.fuelFile);
 		if(svar.restart == 0)
 		{
@@ -898,11 +1069,11 @@ void Write_First_Step(std::fstream& f1, std::fstream& fb, std::fstream& fg,
 				Write_Binary_Timestep(svar,pnp1,0,svar.bndPts,"Boundary",2,svar.boundFile); 
 		}	
 
-		if (svar.ghost == 1 && svar.gout == 1)
-		{
-			/*Write boundary particles*/
-			Init_Binary_PLT(svar,"_ghost.szplt","Ghost Particles",svar.ghostFile);		
-		}	
+		// if (svar.ghost == 1 && svar.gout == 1)
+		// {
+		// 	/*Write boundary particles*/
+		// 	Init_Binary_PLT(svar,"_ghost.szplt","Ghost Particles",svar.ghostFile);		
+		// }	
 	}
 	else
 	{
@@ -939,17 +1110,17 @@ void Write_First_Step(std::fstream& f1, std::fstream& fb, std::fstream& fg,
 			exit(-1);
 		}
 
-		if(svar.ghost == 1 && svar.gout == 1)
-		{
-			string ghostfile = svar.output_prefix;
-			ghostfile.append("_ghost.plt");
-			fg.open(ghostfile,std::ios::out);
-			if(fg.is_open())
-			{
-				Write_ASCII_header(fg,svar);
-				Write_ASCII_Timestep(fg,svar,airP,0,0,airP.size(),"Ghost");
-			}
-		}
+		// if(svar.ghost == 1 && svar.gout == 1)
+		// {
+		// 	string ghostfile = svar.output_prefix;
+		// 	ghostfile.append("_ghost.plt");
+		// 	fg.open(ghostfile,std::ios::out);
+		// 	if(fg.is_open())
+		// 	{
+		// 		Write_ASCII_header(fg,svar);
+		// 		Write_ASCII_Timestep(fg,svar,airP,0,0,airP.size(),"Ghost");
+		// 	}
+		// }
 	}
 
 	if(svar.restart == 0)
@@ -965,15 +1136,15 @@ void Write_First_Step(std::fstream& f1, std::fstream& fb, std::fstream& fg,
 		char* time = ctime(&now);
 		para << "\n";
 		para << "    solver at " << time;
-		para << "                                          " << 
-				"SPH restart-data prefix: " << svar.output_prefix << endl;
+		para << "                                               " << 
+				"SPH restart prefix: " << svar.output_prefix << endl;
 
 		para.close();
 	}
 }
 
 void Write_Timestep(std::fstream& f1, std::fstream& fb, std::fstream& fg, 
-				SIM& svar, SPHState const& pnp1, SPHState const& airP)
+				SIM& svar, SPHState const& pnp1/* , SPHState const& airP */)
 {
 	if (svar.out_encoding == 1)
 	{
@@ -982,8 +1153,8 @@ void Write_Timestep(std::fstream& f1, std::fstream& fb, std::fstream& fg,
 			Write_Binary_Timestep(svar,pnp1,0,svar.bndPts,"Boundary",2,svar.boundFile); 
 		}
 		Write_Binary_Timestep(svar,pnp1,svar.bndPts,svar.totPts,"Fuel",1,svar.fuelFile); /*Write sim particles*/
-		if(svar.ghost != 0 && svar.gout == 1 && airP.size() != 0)
-			Write_Binary_Timestep(svar,airP,0,airP.size(),"Ghost",3,svar.ghostFile);
+		// if(svar.ghost != 0 && svar.gout == 1 && airP.size() != 0)
+		// 	Write_Binary_Timestep(svar,airP,0,airP.size(),"Ghost",3,svar.ghostFile);
 	} 
 	else
 	{
@@ -994,584 +1165,9 @@ void Write_Timestep(std::fstream& f1, std::fstream& fb, std::fstream& fg,
 			Write_ASCII_Timestep(fb,svar,pnp1,1,0,svar.bndPts,"Boundary");
 		}
 
-		if(svar.ghost != 0 && svar.gout == 1 && airP.size() != 0)
-			Write_ASCII_Timestep(fg,svar,airP,0,0,airP.size(),"Ghost");
+		// if(svar.ghost != 0 && svar.gout == 1 && airP.size() != 0)
+		// 	Write_ASCII_Timestep(fg,svar,airP,0,0,airP.size(),"Ghost");
 	}
-}
-
-
-/* Particle tracking functions */
-namespace IPT
-{
-	void Write_ASCII_variables(ofstream& fp)
-	{
-		string variables = 
-	"\"X\", \"Y\", \"Z\", \"t\", \"dt\", \"v\", \"a\", \"ptID\", \"Cell_V\", \"Cell_Rho\", \"Cell_ID\"";
-
-		fp << "VARIABLES = " << variables << "\n";
-	}
-
-	void Write_ASCII_Scatter_Header(ofstream& fp)
-	{
-		fp << "TITLE =\"IPT particle scatter data\" \n";
-		fp << "F=POINT\n";
-		fp << std::left << std::scientific << std::setprecision(6);
-	}
-
-	void Write_ASCII_Streaks_Header(ofstream& fout)
-	{
-		fout << "TITLE = \"IPT Streaks\"\n";
-		Write_ASCII_variables(fout);
-	}
-
-	void Write_ASCII_Cells_Header(ofstream& fout)
-	{
-		fout << "TITLE = \"IPT intersecting cells\"\n";
-		fout << "VARIABLES= \"X\" \"Y\" \"Z\" " << endl;
-	}
-	
-	void Init_IPT_Files(SIM& svar)
-	{
-		string partf, cellf, streakf, surfacef;
-
-		partf = svar.output_prefix;
-		partf.append("_IPT_scatter.dat");
-
-		streakf = svar.output_prefix;
-		streakf.append("_IPT_streaks.dat");
-
-		cellf = svar.output_prefix;
-		cellf.append("_IPT_cells.dat");
-
-		surfacef = svar.output_prefix;
-		surfacef.append("_surface_impacts.dat");
-
-		if(svar.partout == 1)
-		{
-			svar.partfile.open(partf,std::ios::in);
-			
-			if(svar.partfile.is_open())
-			{
-				Write_ASCII_Scatter_Header(svar.partfile);
-			}
-			else
-			{
-				cout << "Couldn't open the IPT particle scatter output file." << endl;
-				exit(-1);
-			}
-		}
-
-		if(svar.streakout == 1)
-		{
-			svar.streakfile.open(streakf,std::ios::in);
-
-			if(svar.streakfile.is_open())
-			{
-				Write_ASCII_Streaks_Header(svar.streakfile);
-			}
-			else
-			{
-				cout << "Couldn't open the IPT streaks output file." << endl;
-				exit(-1);
-			}
-		}
-
-		if(svar.cellsout == 1)
-		{
-			svar.cellfile.open(cellf,std::ios::in);
-
-			if(svar.cellfile.is_open())
-			{
-				Write_ASCII_Cells_Header(svar.cellfile);
-			}
-			else
-			{
-				cout << "Couldn't open the IPT cell intersection output file." << endl;
-				exit(-1);
-			}
-		}
-
-		// svar.surfacefile.open(surfacef,std::ios::in);
-	}
-
-	void Write_ASCII_Point(ofstream& fp, real const& scale, IPTPart const& pnp1)
-	{
-		const static uint width = 15;
-
-		for(uint dim = 0; dim < 3; ++dim)
-			fp << setw(width) << pnp1.xi[dim]/scale;
-
-		fp << setw(width) << pnp1.t; 
-
-		fp << setw(width) << pnp1.dt; 
-		
-		fp << setw(width) << pnp1.v.norm(); 
-
-		fp << setw(width) << pnp1.acc; 
-
-		fp << setw(width) << pnp1.partID;
-
-		fp << setw(width) << pnp1.cellV.norm();
-
-		fp << setw(width) << pnp1.cellRho;
-		fp << setw(width) << pnp1.cellID << "\n"; 
-	}
-
-	void Write_ASCII_Timestep(ofstream& fp, SIM const& svar, IPTState const& pnp1)
-	{
-		fp <<  "ZONE T=\"" << "IPT scatter data" << "\"";
-		fp <<", I=" << pnp1.size() << ", F=POINT" <<", STRANDID=1, SOLUTIONTIME=" << svar.t  << "\n";
-		fp << std::left << std::scientific << std::setprecision(6);
-		
-		for (size_t ii = 0; ii < pnp1.size(); ++ii)
-		{
-			Write_ASCII_Point(fp, svar.scale, pnp1[ii]);
-		}
-		fp << std::flush;
-	}
-
-	void Write_ASCII_Streaks( SIM& svar, IPTState const& t_pnp1, IPTPart const& pnp1)
-	{
-		ofstream& fp = svar.streakfile;
-		if(!fp.is_open())
-		{
-			cout << "The streak output file is not open. Cannot write." << endl;
-			exit(-1);
-		}
-		
-		size_t nTimes = t_pnp1.size();
-		size_t time = 0;
-		
-		fp <<  "ZONE T=\"" << "Ash particle " << pnp1.partID << "\"";
-		
-		if(pnp1.failed == 0)
-			fp <<", I=" << nTimes+1 << ", J=1, K=1, DATAPACKING=POINT"<< "\n";
-		else
-			fp <<", I=" << nTimes << ", J=1, K=1, DATAPACKING=POINT"<< "\n";
-
-		fp << std::left << std::scientific << std::setprecision(6);
-
-		for (time = 0; time < nTimes; ++time)
-		{ /* Inner loop to write the times of the particle */
-			Write_ASCII_Point(fp, svar.scale, t_pnp1[time]);
-		}
-
-		if(pnp1.failed == 0)
-			Write_ASCII_Point(fp, svar.scale, pnp1);
-
-	}
-
-
-	void Write_ASCII_Cells(SIM& svar, MESH const& cells, IPTState const& t_pnp1)
-	{
-		size_t nTimes = t_pnp1.size();
-		size_t time = 0;
-
-		/* Write file for each particle. Gonna get way too confusing otherwise */
-		ofstream& fout = svar.cellfile;
-
-		if(!fout.is_open())
-		{
-			cout << "Couldn't open the cell intersection output file." << endl;
-			exit(-1);
-		}
-
-		int TotalNumFaceNodes = 0;
-
-		vector<size_t> vertIndexes;
-		vector<size_t> faceIndexes;
-		vector<int> cellIndexes;
-
-		vector<StateVecD> usedVerts;
-		vector<vector<size_t>> faces;
-		vector<int> left;
-		vector<int> right;
-
-
-		/* Get cell properties for the intersected cells (delete duplicates later)*/
-		for (time = 0; time < nTimes; ++time)
-		{
-			int cellID = t_pnp1[time].cellID;
-			
-			/* Find how many vertices the cell has */
-			vertIndexes.insert(vertIndexes.end(), cells.elems[cellID].begin(), cells.elems[cellID].end());
-			
-			faceIndexes.insert(faceIndexes.end(), cells.cFaces[cellID].begin(), cells.cFaces[cellID].end());
-
-			cellIndexes.emplace_back(cellID);
-		}
-
-		/* Delete repeats of vertex mentions*/
-		std::sort(vertIndexes.begin(),vertIndexes.end());
-		vertIndexes.erase( std::unique( vertIndexes.begin(), vertIndexes.end()), vertIndexes.end() );
-
-		std::sort(faceIndexes.begin(),faceIndexes.end());
-		faceIndexes.erase( std::unique( faceIndexes.begin(), faceIndexes.end()), faceIndexes.end() );
-
-		for(size_t const& vert : vertIndexes)
-		{
-			usedVerts.emplace_back(cells.verts[vert]);
-		}
-
-		/* Get faces properties used in the cell */
-		for(size_t const& face: faceIndexes )
-		{
-			faces.emplace_back(cells.faces[face]);
-			left.emplace_back(cells.leftright[face].first);
-			right.emplace_back(cells.leftright[face].second);
-		}
-
-		/* Go through the faces indexes, finding the appropriate index to change it to */
-
-		for(vector<size_t>& face : faces)
-		{
-			for(size_t& vert : face)
-			{
-				vector<size_t>::iterator index = std::find(vertIndexes.begin(), vertIndexes.end(), vert);
-				if(index != vertIndexes.end())
-				{
-					vert = index - vertIndexes.begin() + 1 ;
-				}
-				else
-				{
-					cout << "Couldn't find the vertex used in the prepared list." << endl;
-					exit(-1);
-				}                
-			}
-			TotalNumFaceNodes += face.size();
-		}
-
-		/* Find the cell used and change it's index */
-		for(int& leftCell:left)
-		{
-			vector<int>::iterator index = std::find(cellIndexes.begin(), cellIndexes.end(), leftCell);
-			if(index != cellIndexes.end())
-			{
-				leftCell = (index - cellIndexes.begin())+1;
-			}
-			else
-			{   /* Cell isn't intersected, so it won't be drawn. Boundary face. */
-				leftCell = 0;
-			} 
-		}
-
-		for(int& rightCell:right)
-		{
-			vector<int>::iterator index = std::find(cellIndexes.begin(), cellIndexes.end(), rightCell);
-			if(index != cellIndexes.end())
-			{
-				rightCell = index - cellIndexes.begin() + 1;
-			}
-			else
-			{   /* Cell isn't intersected, so it won't be drawn. Boundary face. */
-				rightCell = 0;
-			}
-		}
-
-		fout << "ZONE T=\"particle " << t_pnp1[0].partID << " intersecting cells\"" << endl;
-		fout << "ZONETYPE=FEPOLYHEDRON" << endl;
-		fout << "NODES=" << usedVerts.size() << " ELEMENTS=" << cellIndexes.size() << 
-				" FACES=" << faces.size() << endl;
-		fout << "TotalNumFaceNodes=" << TotalNumFaceNodes << endl;
-		fout << "NumConnectedBoundaryFaces=0 TotalNumBoundaryConnections=0" << endl;
-
-		size_t w = 15;
-		size_t preci = 6;
-		fout << std::left << std::scientific << std::setprecision(preci);
-
-		size_t newl = 0;
-		fout << std::setw(1);
-		for(size_t DIM = 0; DIM < 3; ++DIM)
-		{
-			for(size_t ii = 0; ii < usedVerts.size(); ++ii)
-			{
-				fout << std::setw(w) << usedVerts[ii][DIM];
-				newl++;
-
-				if(newl>4)
-				{
-					fout << endl;
-					fout << " ";
-					newl=0;
-				}
-			}
-		}
-		fout << endl;
-
-		fout << std::left << std::fixed;
-		w = 9;
-		/*Inform of how many vertices in each face*/
-		fout << "#node count per face" << endl;
-		newl = 0;
-		for (size_t ii = 0; ii < faces.size(); ++ii)
-		{
-			fout << std::setw(w) << faces[ii].size();
-			newl++;
-
-			if(newl>4)
-			{
-				fout << endl;
-				newl=0;
-			}
-		}
-		fout << endl;
-		/*Write the face data*/
-		fout << "#face nodes" << endl;
-		for (size_t ii = 0; ii < faces.size(); ++ii)
-		{
-			for(auto const& vertex:faces[ii])
-			{	/*Write face vertex indexes*/
-				fout << std::setw(w) << vertex;
-				// if (vertex > fdata.nPnts)
-				// {
-				// 	cout << "Trying to write a vertex outside of the number of points." << endl;
-				// }
-			}
-			fout << endl;
-		}
-
-		/*Write face left and right*/
-		newl = 0;
-		fout << "#left elements" << endl;
-		for (size_t ii = 0; ii < left.size(); ++ii)
-		{
-			fout << std::setw(w) << left[ii] ;
-			newl++;
-
-			if(newl>4)
-			{
-				fout << endl;
-				newl=0;
-			}
-		}
-		fout << endl;
-
-		newl = 0;
-		fout << "#right elements" << endl;
-		for (size_t ii = 0; ii < right.size(); ++ii)
-		{
-			fout << std::setw(w) << right[ii] ;
-			newl++;
-
-			if(newl>4)
-			{
-				fout << endl;
-				newl=0;
-			}
-		}
-
-		fout.close();
-	}
-
-
-	void Write_ASCII_Impacts(SIM const& svar, FLUID const& fvar, MESH const& cells, 
-				vector<SURF> const& surfs, vector<vector<real>> const& beta_data)
-	{
-		// uint nSurf = svar.markers.size();
-		uint nSurf = 0;
-		vector<int> marks;
-		vector<string> names;
-		vector<SURF> surfaces_to_write;
-		for(size_t ii = 0; ii < surfs.size(); ii++)
-		{
-			if(surfs[ii].output == 1)
-			{
-				marks.emplace_back(svar.markers[ii]);
-				names.emplace_back(svar.bnames[ii]);
-				surfaces_to_write.emplace_back(surfs[ii]);
-			}
-			nSurf += surfs[ii].output;
-		}
-
-		nSurf = 0;
-		for(size_t ii = 0; ii < surfs.size(); ii++)
-		{
-			if(surfs[ii].output == 1)
-			{
-				surfaces_to_write[nSurf].face_count = surfs[ii].face_count;
-				surfaces_to_write[nSurf].face_beta = surfs[ii].face_beta;
-				surfaces_to_write[nSurf].face_area = surfs[ii].face_area;
-			}
-			nSurf += surfs[ii].output;
-		}
-		
-
-		vector<vector<vector<size_t>>> faces(nSurf);
-		vector<std::pair<size_t,int>> smarkers = cells.smarkers;
-
-		vector<vector<size_t>> vertIndexes(nSurf);
-		vector<vector<StateVecD>> usedVerts(nSurf);
-		
-		/* Do I need to sort the markers? */
-		std::sort(smarkers.begin(), smarkers.end(),
-		[](std::pair<size_t,int> const& p1, std::pair<size_t,int> const& p2){return p1.second > p2.second;});
-
-		
-		for(size_t ii = 0; ii < surfaces_to_write.size(); ++ii)
-		{
-
-			for(size_t jj = 0; jj < surfaces_to_write[ii].faceIDs.size(); ++jj )
-			{
-				size_t faceID = surfaces_to_write[ii].faceIDs[jj];
-				faces[ii].emplace_back(cells.faces[faceID]);
-			}
-		
-			/* Get the vertex indexes, delete duplicates, reorder, and recast the face indexes */
-			for (vector<size_t> const& face : faces[ii])
-				vertIndexes[ii].insert(vertIndexes[ii].end(), face.begin(), face.end());
-			
-
-			std::sort(vertIndexes[ii].begin(),vertIndexes[ii].end());
-			vertIndexes[ii].erase(std::unique( vertIndexes[ii].begin(), vertIndexes[ii].end()), vertIndexes[ii].end() );
-
-			for(size_t const& vert : vertIndexes[ii])
-				usedVerts[ii].emplace_back(cells.verts[vert]);
-		
-
-			for(vector<size_t>& face : faces[ii])
-			{
-				for(size_t& vert : face)
-				{
-					vector<size_t>::iterator index = std::find(vertIndexes[ii].begin(), vertIndexes[ii].end(), vert);
-					if(index != vertIndexes[ii].end())
-					{
-						vert = index - vertIndexes[ii].begin() + 1 ;
-					}
-					else
-					{
-						cout << "Couldn't find the vertex used in the prepared list." << endl;
-						exit(-1);
-					}                
-				}
-			}
-		}
-
-		
-		string file = svar.output_prefix;
-		file.append("_surface_impacts.dat");
-
-		ofstream fout(file);
-
-		if(!fout.is_open())
-		{
-			cout << "Couldn't open the surface impact output file." << endl;
-			exit(-1);
-		}
-
-		fout << "TITLE=\"Surface collision metrics\"\n";
-		fout << "VARIABLES= \"X\" \"Y\" \"Z\" \"Number of Impacts\" \"beta\" \"average area\"\n";
-		
-		for(size_t ii = 0; ii < faces.size(); ++ii)
-		{
-			fout << "ZONE T=\"" << names[ii] << "\"\n";
-			fout << "N=" << usedVerts[ii].size() << ", E=" << faces[ii].size();
-			fout << ", F=FEBLOCK ET=QUADRILATERAL, VARLOCATION=([1-3]=NODAL,[4-7]=CELLCENTERED)\n\n";
-			
-			
-			size_t w = 15;
-			size_t preci = 6;
-			fout << std::left << std::scientific << std::setprecision(preci);
-
-			size_t newl = 0;
-			fout << std::setw(1);
-			for(size_t DIM = 0; DIM < SIMDIM; ++DIM)
-			{
-				for(size_t jj = 0; jj < usedVerts[ii].size(); ++jj)
-				{
-					fout << std::setw(w) << usedVerts[ii][jj][DIM];
-					newl++;
-
-					if(newl>4)
-					{
-						fout << endl;
-						fout << " ";
-						newl=0;
-					}
-				}
-			}
-			fout << endl << endl;
-
-			/* Variable data goes here */
-			fout << "#face impact count" << endl;
-			for(size_t jj = 0; jj < surfaces_to_write[ii].face_count.size(); ++jj)
-			{
-				fout << std::setw(w) << surfaces_to_write[ii].face_count[jj];
-				newl++;
-
-				if(newl>4)
-				{
-					fout << endl;
-					fout << " ";
-					newl=0;
-				}
-			}
-			fout << endl << endl;
-
-			// for(size_t jj = 0; jj < surfs[surf].mass.size(); ++jj)
-			// {
-			//     fout << std::setw(w) << surfs[surf].mass[jj];
-			//     newl++;
-
-			//     if(newl>4)
-			//     {
-			//         fout << endl;
-			//         fout << " ";
-			//         newl=0;
-			//     }
-			// }
-			// fout << endl;
-			fout << "#face beta value" << endl; 
-			for(size_t jj = 0; jj < surfaces_to_write[ii].face_beta.size(); ++jj)
-			{
-				fout << std::setw(w) << surfaces_to_write[ii].face_beta[jj];
-				newl++;
-
-				if(newl>4)
-				{
-					fout << endl;
-					fout << " ";
-					newl=0;
-				}
-			}
-			fout << endl << endl;
-
-			fout << "#face area value" << endl;
-			for(size_t jj = 0; jj < surfaces_to_write[ii].face_area.size(); ++jj)
-			{
-				fout << std::setw(w) << surfaces_to_write[ii].face_area[jj];
-				newl++;
-
-				if(newl>4)
-				{
-					fout << endl;
-					fout << " ";
-					newl=0;
-				}
-			}
-			fout << endl << endl;
-
-
-			/*Write the face data*/
-			fout << "#face nodes" << endl;
-			for (size_t jj = 0; jj < faces[ii].size(); ++jj)
-			{
-				for(auto const& vertex:faces[ii][jj])
-				{	/*Write face vertex indexes*/
-					fout << std::setw(w) << vertex;
-					// if (vertex > fdata.nPnts)
-					// {
-					// 	cout << "Trying to write a vertex outside of the number of points." << endl;
-					// }
-				}
-
-				if(faces[ii][jj].size() == 3)
-					fout << std::setw(w) << faces[ii][jj].back();
-
-				fout << endl;
-			}
-		}
-		fout.close();
-	}   
 }
 
 #endif

--- a/src/IOFunctions.h
+++ b/src/IOFunctions.h
@@ -1,9 +1,9 @@
+
 #ifndef IOFUNCTIONS_H
 #define IOFUNCTIONS_H
 	
 
 #include "Var.h"
-#include "BinaryIO.h"
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdio.h>  /* defines FILENAME_MAX */
@@ -18,7 +18,6 @@
     #define GetCurrentDir getcwd
 #endif
 
-const std::string WHITESPACE = " \n\r\t\f\v";
 
 void write_header() 
 {
@@ -100,88 +99,113 @@ void Check_If_Restart_Possible(SIM const& svar)
   	/*Check output folder for any prexisting files*/
   	if(svar.out_encoding == 1)
   	{
-  		string file = svar.restart_prefix;
-  		file.append("_fuel.szplt.szdat");
+		cout << "Checking for previous fluid files..." << endl;
+  		struct stat info;
+
+		// Check if there is the constructed szplt
+  		string file = svar.restart_prefix + "_fuel.szplt";
 		#ifdef DEBUG
-			dbout << "Checking for existence of previous szplt files." << endl;
+			dbout << "Checking for existence of szplt file." << endl;
 			dbout << "Path: " << file << endl;
 		#endif
-  		struct stat info;
   		if(stat( file.c_str(), &info ) == 0)
   		{
-  			// cout << "Split files exist..." << endl;
+  			// cout << "Combined file exists..." << endl;
+			auto sztime = info.st_mtime;
 
-			// Check if there is the constructed szplt
-			file = svar.restart_prefix;				
-			file.append("_fuel.szplt");
-			if(stat( file.c_str(), &info ) != 0)
-			{	/*Fuel.szplt does not exist - needs creating*/
-				if(Combine_SZPLT(file) == -1)
-					exit(-1);
-			}
-			else
+			file = svar.restart_prefix + "_fuel.szplt.szdat";
+			#ifdef DEBUG
+				dbout << "Checking for existence of uncombined szplt file." << endl;
+				dbout << "Path: " << file << endl;
+			#endif
+
+			if(stat( file.c_str(), &info ) == 0)
 			{	// Both the combined and split szplt exist - check which is more recent.
 				// cout << "Both file types exist" << endl << endl;
-				auto sztime = info.st_mtime;
-				file.append(".szdat");
-				if(stat(file.c_str(), &info) == 0)
-				{
-					auto szdattime = info.st_mtime;
-					if (szdattime > (sztime+10))
-					{	// combine the files
-						file = svar.output_prefix;
-						file.append("_fuel.szplt");
-						if(Combine_SZPLT(file) == -1)
-							exit(-1);
-					}
+				auto szdattime = info.st_mtime;
+				if (szdattime > (sztime+10))
+				{	// combine the files
+					file = svar.output_prefix + "_fuel.szplt";
+					if(Combine_SZPLT(file) == -1)
+						exit(-1);
 				}
 			}
 		}
 		else
-		{
-			cout << "The fuel szplt files needed to restart could not be found. Stopping." << endl;
-			exit(-1);
+		{	/* Combined file doesnt exist. Can it be created? */
+			file = svar.restart_prefix + "_fuel.szplt.szdat";
+			#ifdef DEBUG
+				dbout << "Checking for existence of uncombined szplt file." << endl;
+				dbout << "Path: " << file << endl;
+			#endif
+
+			if(stat( file.c_str(), &info ) == 0)
+			{
+				// combine the files
+				file = svar.restart_prefix + "_fuel.szplt";
+				if(Combine_SZPLT(file) == -1)
+					exit(-1);
+			}
+			else
+			{	/* Neither set of files exist, so no data - can't restart */
+				cout << "The fuel szplt files needed to restart could not be found. Stopping." << endl;
+				exit(-1);
+			}
+
 		}
 
 		if(svar.Bcase != 0)
 		{
-			file = svar.restart_prefix;
-			file.append("_boundary.szplt.szdat");
-
+			cout << "Checking for previous boundary files..." << endl;
+			file = svar.restart_prefix + "_boundary.szplt";
+			#ifdef DEBUG
+				dbout << "Checking for existence of szplt file." << endl;
+				dbout << "Path: " << file << endl;
+			#endif
 			if(stat( file.c_str(), &info ) == 0)
 			{
-				// cout << "Split files exist..." << endl;
-				// Check if there is the constructed szplt
-				file = svar.restart_prefix;				
-				file.append("_boundary.szplt");
-				if(stat( file.c_str(), &info ) != 0)
-				{	/*Fuel.szplt does not exist - needs creating*/
+				auto sztime = info.st_mtime;
+				// cout << "Combined file exists..." << endl;
+				// Check if there is the unconstructed szplt
+				file = svar.restart_prefix + "_boundary.szplt.szdat";				
+				#ifdef DEBUG
+					dbout << "Checking for existence of uncombined szplt file." << endl;
+					dbout << "Path: " << file << endl;
+				#endif
+		
+				if(stat( file.c_str(), &info ) == 0)
+				{	// Both the combined and split szplt exist - check which is more recent.
+					// cout << "Both file types exist" << endl << endl;
+					auto szdattime = info.st_mtime;
+					if (szdattime > (sztime+10))
+					{	// combine the files
+						file = svar.restart_prefix;
+						file.append("_boundary.szplt");
+						if(Combine_SZPLT(file) == -1)
+							exit(-1);
+					}	
+				}
+			}
+			else
+			{ 	/* Combined file doesnt exist. Can it be created? */
+				file = svar.restart_prefix + "_boundary.szplt.szdat";				
+				#ifdef DEBUG
+					dbout << "Checking for existence of uncombined szplt file." << endl;
+					dbout << "Path: " << file << endl;
+				#endif
+		
+				if(stat( file.c_str(), &info ) == 0)
+				{	
+					file = svar.restart_prefix + "_boundary.szplt";
 					if(Combine_SZPLT(file) == -1)
 						exit(-1);
 				}
 				else
-				{	// Both the combined and split szplt exist - check which is more recent.
-					// cout << "Both file types exist" << endl << endl;
-					auto sztime = info.st_mtime;
-					file.append(".szdat");
-					if(stat(file.c_str(), &info) == 0)
-					{
-						auto szdattime = info.st_mtime;
-						if (szdattime > (sztime+10))
-						{	// combine the files
-							file = svar.restart_prefix;
-							file.append("_boundary.szplt");
-							if(Combine_SZPLT(file) == -1)
-								exit(-1);
-						}
-					}
+				{
+					cout << "The boundary szplt files needed to restart could not be found. Stopping." << endl;
+					exit(-1);
 				}
-			}
-			else
-			{
-				cout << "The boundary szplt files needed to restart could not be found. Stopping." << endl;
-				exit(-1);
-			}			
+			}	
 		}
   	}
 }
@@ -310,7 +334,7 @@ void Get_Vector(string const& line, string const& param,
 }
 
 void Get_Vector(string const& line, string const& param, 
-				Eigen::Matrix<int,2,1>/* vec<int,2> */ &value)
+				Eigen::Matrix<int,2,1>& value)
 {
     if(line.find(param) != string::npos)
     {
@@ -332,12 +356,33 @@ void Get_Vector(string const& line, string const& param,
     }
 }
 
-uint index(uint ii, uint jj, uint nPts)
+template<typename T>
+void Get_Array(string const& line, string const& param, 
+				vector<T>& value)
 {
-	return(ii*nPts + jj);
+    if(line.find(param) != string::npos)
+    {
+        string temp = Get_Parameter_Value(line);
+        std::istringstream iss(temp);
+        
+        T a;
+        string temp2;
+        
+		while(std::getline(iss,temp2,','))
+		{
+			std::istringstream iss2(temp2);
+			iss2 >> a;
+			value.emplace_back(a);
+		} 
+    }
 }
 
-std::ifstream& GotoLine(std::ifstream& file, unsigned int num)
+inline const uint index(uint ii, uint jj, uint nii)
+{
+	return(ii + jj*nii);
+}
+
+inline std::ifstream& GotoLine(std::ifstream& file, unsigned int num)
 {
     file.seekg(std::ios::beg);
     for(uint ii=0; ii < num - 1; ++ii){
@@ -346,395 +391,11 @@ std::ifstream& GotoLine(std::ifstream& file, unsigned int num)
     return file;
 }
 
-void CheckContents(void* const& inputHandle, SIM& svar, int32_t& numZones, double& time)
-{
-	int32_t numVars, I;
-	I = tecDataSetGetNumVars(inputHandle, &numVars);
 
-	std::ostringstream outputStream;
-    for (int32_t var = 1; var <= numVars; ++var)
-    {
-        char* name = NULL;
-        I = tecVarGetName(inputHandle, var, &name);
-        outputStream << name;
-        if (var < numVars)
-            outputStream << ',';
-        tecStringFree(&name);
-    }
 
-	if (I == -1)
-	{
-		cout << "Couldn't obtain number of variables. Stopping" << endl;
-		exit(-1);
-	}
 
-	cout << "Number of variables in output file: " << numVars << endl;
 
-	uint dataType = 0;
-#if SIMDIM == 2
-	if( outputStream.str() == "X,Z")
-		dataType = 0;
 
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v,a,partID")
-		dataType = 1;
-
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID")
-		dataType = 2;	
-
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,Cell_Vx,Cell_Vz,Cell_P,Cell_Rho,Cell_ID" )
-		dataType = 3;
-
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v,a,partID,Neighbours,Aero")
-		dataType = 4;
-
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,Cell_ID")
-		dataType = 5;
-
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,lambda,surface")
-		dataType = 6;
-
-	else if (outputStream.str() == "X,Z,Rrho,rho,press,m,v_x,v_z,a_x,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z")
-		dataType = 7;
-
-#else
-	if( outputStream.str() == "X,Y,Z")
-		dataType = 0;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v,a,partID")
-		dataType = 1;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID")
-		dataType = 2;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_Vx,Cell_Vy,Cell_Vz,Cell_P,Cell_Rho,Cell_ID")
-		dataType = 3;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v,a,partID,Neighbours,Aero")
-		dataType = 4;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,Cell_ID")
-		dataType = 5;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface")
-		dataType = 6;
-
-	else if (outputStream.str() == "X,Y,Z,Rrho,rho,press,m,v_x,v_y,v_z,a_x,a_y,a_z,b,partID,lambda,surface,a_aero_x,a_aero_z")
-		dataType = 7;
-	
-#endif
-	cout << "Variables:  " << outputStream.str() << "  Data type: " << dataType << endl;
-
-	if(dataType == 0 || dataType == 1 || dataType == 4)
-	{
-		cout << "Cannot restart. File does not contain the correct information." << endl;
-		exit(-1);
-	}
-
-    if(dataType!= svar.outform)
-    {
-    	cout << "Data is different from that in the restfings file." << endl;
-    	cout << "Changing to the file data type: " << dataType << endl;
-    }
-
-    I = tecDataSetGetNumZones(inputHandle, &numZones);
-    cout << "Number of zones in file: " << numZones << endl;
-
-    I = tecZoneGetSolutionTime(inputHandle, numZones, &time);
-    cout << "Latest zone time: " << time << endl << endl;
-}
-
-void Restart(SIM& svar, FLUID const& fvar, AERO const& avar, MESH const& cells, SPHState& pn, SPHState& pnp1)
-{	
-	// Read the values from the solution folder, then check. 
-
-	// Check that a restart can be performed. 
-	if(svar.outform == 0 || svar.outform == 1 || svar.outform == 4)
-	{
-		cout << "Output type cannot be restarted from. Make sure that you have the correct output selected." << endl;
-		exit(-1);
-	}
-
-	if(svar.Asource != 0)
-	{
-		if(svar.outform != 3 || svar.outform != 5)
-		{
-			cout << "No cell information. Cannot restart" << endl;
-			exit(-1);
-		}
-	}
-
-	#ifdef DEBUG
-		dbout << "Reading frame info file for restart information." << endl;
-	#endif
-
-	// Re-read the settings and fluid file
-	// cout << svar.outfolder << endl;
-
-	// Now get the data from the files. Start with the boundary
-	if(svar.out_encoding == 1)
-	{
-		SPHState boundary, fuel, rest;	
-
-		// Read the fuel
-		void* fuelHandle = NULL;
-		void* boundHandle = NULL;
-
-		int32_t fuelFrames, boundFrames;
-		double fuelTime, boundTime;
-
-		string fuelf = svar.output_prefix;
-		fuelf.append("_fuel.szplt");
-
-		if(tecFileReaderOpen(fuelf.c_str(),&fuelHandle))
-		{
-			cout << "Error opening szplt file. Path:" << endl;
-			cout << fuelf << endl;
-			exit(-1);
-		}
-
-		// Check how many frames are in the fuel file.
-		cout << "Checking Fuel file..." << endl;
-		CheckContents(fuelHandle,svar,fuelFrames,fuelTime);
-
-		if (svar.Bcase !=0)
-		{
-			string boundf = svar.output_prefix;
-			boundf.append("_boundary.szplt");
-
-			if(tecFileReaderOpen(boundf.c_str(),&boundHandle))
-			{
-				cout << "Error opening szplt file. Path:" << endl;
-				cout << boundf << endl;
-				exit(-1);
-			}
-
-			cout << "Checking Boundary file..." << endl;
-			CheckContents(boundHandle,svar,boundFrames,boundTime);
-
-			if(fuelFrames!= boundFrames)
-			{
-				cout << "Caution! Number of frames is not consistent between fuel and boundary files." << endl;
-			}
-
-			if(fuelTime != boundTime)
-			{
-				cout << "Caution! Frame times are not consistent between fuel and boundary files." << endl;
-
-				if(fuelTime > boundTime)
-				{
-					double time = 0.0;
-					for(int32_t frame = fuelFrames-1; frame > 1; frame--)
-					{
-						if(tecZoneGetSolutionTime(fuelHandle, frame, &time))
-						{
-							cout << "Failed to get time data for frame : " << frame << " from fuel file." << endl;
-							continue;
-						}
-						
-						if(time == boundTime)
-						{
-							cout << "Found the correct frame" << endl;
-							fuelFrames = frame;
-							fuelTime = time;
-							break;
-						}
-					}
-				}
-				else
-				{
-					double time = 0.0;
-					for(int32_t frame = boundFrames-1; frame >= 1; frame--)
-					{
-						if(tecZoneGetSolutionTime(boundHandle, frame, &time))
-						{
-							cout << "Failed to get time data for frame : " << frame << " from boundary file." << endl;
-							continue;
-						}
-						
-
-						if(time == fuelTime)
-						{
-							cout << "Found the correct frame" << endl;
-							boundFrames = frame;
-							boundTime = time;
-							break;
-						}
-					}
-				}
-
-				if(fuelTime != boundTime)
-				{
-					cout << "Could not find a consistent time in each file. Stopping." << endl;
-					exit(-1);
-				}
-			}
-
-			cout << "Attempting to read the boundary..." << endl;
-			Read_Binary_Timestep(boundHandle,svar,boundFrames,boundary);
-		}
-
-	    svar.frame = fuelFrames-1;
-
-	    // Read the actual data.
-		cout  << "Attempting to read the fuel..." << endl;
-		Read_Binary_Timestep(fuelHandle,svar,fuelFrames,fuel);
-
-
-		pn = boundary;
-		svar.bndPts = boundary.size();
-		svar.simPts = fuel.size();
-		pn.insert(pn.end(),fuel.begin(),fuel.end());	
-		svar.totPts = pn.size();
-		
-		if(svar.simPts + svar.bndPts != svar.totPts)
-		{
-			cout << "Mismatch of array sizes. Total array is not the sum of sim and boundary arrays" << endl;
-			exit(-1);
-		}
-
-		// Check the frame timings to ensure dt does not go negative.
-		double frametime = svar.framet * real(fuelFrames-1);
-
-		if(svar.t > frametime)
-		{
-			// There's a problem with the frame times.
-			cout << "Time is further ahead than what is supposed by the frame timings." << endl;
-			cout << "Need to adjust frame time to match the current time" << endl;
-
-			real framet = svar.t/real(fuelFrames-1.0);
-			cout << "Old frame time: " << svar.framet << "  New frame time: " << framet << endl << endl;
-			svar.framet = framet;			
-		}
-
-		// if(svar.totPts != totPts || svar.bndPts != bndPts || svar.simPts != simPts)
-		// {
-		// 	cout << "Mismatch of the particle numbers in the frame file and data file." << endl;
-		// }
-	}
-	else
-	{
-		// TODO: ASCII Restart.
-		// Particle numbers can be found from frame file.
-		// Find EOF, then walk back from there how many particles.
-
-		cout << "ASCII file restart not yet implemented." << endl;
-		exit(-1);
-	}
-
-	// Go through the particles giving them the properties of the cell
-	size_t pID = 0;
-	vector<size_t> buffer;
-	#pragma omp parallel for 
-	for(size_t ii = 0; ii < svar.totPts; ++ii)
-	{
-		/* Set density based on pressure. More information this way */
-		pn[ii].rho = fvar.rho0*pow((pn[ii].p/fvar.B) + 1.0, 1.0/fvar.gam);
-
-		if(pn[ii].b == PartState.BACK_)
-		{
-			#pragma omp critical
-			svar.back.emplace_back(ii);
-		}
-		else if(pn[ii].b == PartState.BUFFER_)
-		{
-			#pragma omp critical
-			buffer.emplace_back(ii);
-		}
-
-		if(svar.Asource == 0)
-		{
-			pn[ii].cellRho = avar.rhog;
-		}
-		
-		// Initialise the rest of the values to 0
-		pn[ii].s = 0.0;
-		pn[ii].woccl = 0.0;
-		pn[ii].pDist = 0.0;
-		pn[ii].internal = 0;
-
-		pn[ii].vPert = StateVecD::Zero();
-
-		#pragma omp critical
-		{
-			if(pn[ii].partID > pID)
-				pID = pn[ii].partID;
-		}
-	}	
-
-	svar.partID = pID+1;
-
-	/* Put the particles into the buffer vector */
-	svar.buffer = vector<vector<size_t>>(svar.back.size(),vector<size_t>(4));
-	real eps = 0.01*svar.dx; /* Tolerance value */
-	for(size_t ii = 0; ii < svar.back.size(); ++ii)
-	{
-		StateVecD const test = svar.Transp*(pn[svar.back[ii]].xi-svar.sim_start);
-		
-		for(size_t index = 0; index < buffer.size(); ++index)
-		{
-			/* Check which particle in the back vector it corresponds to by checking which  */
-			/* particle it lies behind */
-			StateVecD const xi = svar.Transp*(pn[buffer[index]].xi-svar.sim_start);
-			// cout << test[0] << "  " << test[1] << "  " << xi[0] << "  " << xi[1] << endl;
-
-			if(xi[0] < test[0] + eps && xi[0] > test[0] - eps)
-			{	/* X coordinate is within bounds, so should lie behind this point */
-
-				/* Start wit the furthest away, and go closer */
-				if (xi[1] < test[1] - 4.0*svar.dx + eps)
-				{
-					svar.buffer[ii][3] = buffer[index];
-				}
-				else if (xi[1] < test[1] - 3.0*svar.dx + eps)
-				{
-					svar.buffer[ii][2] = buffer[index];
-				}
-				else if (xi[1] < test[1] - 2.0*svar.dx + eps)
-				{
-					svar.buffer[ii][1] = buffer[index];
-				}
-				else if (xi[1] < test[1] - svar.dx + eps)
-				{
-					svar.buffer[ii][0] = buffer[index];
-				}
-				else
-				{
-					cout << "Couldn't identify where to place the buffer particle" << endl;
-					exit(-1);
-				}
-			}
-		}
-	}	
-	
-	pnp1 = pn;
-}
-
-
-void GetYcoef(AERO& avar, const FLUID& fvar, const real diam)
-{
-	#if SIMDIM == 3
-		avar.L = diam * std::cbrt(3.0/(4.0*M_PI));
-	#endif
-	#if SIMDIM == 2
-		avar.L = diam/sqrt(M_PI);
-	#endif
-
-	// avar.L = diam / 2.0; pow(diam,1.25)/2.0;
-
-	
-	avar.td = (2.0*fvar.rho0*pow(avar.L,SIMDIM-1))/(avar.Cd*fvar.mu);
-
-	avar.omega = sqrt((avar.Ck*fvar.sig)/(fvar.rho0*pow(avar.L,SIMDIM))-1.0/pow(avar.td,2.0));
-
-	avar.tmax = -2.0 *(atan(sqrt(pow(avar.td*avar.omega,2.0)+1)
-					+avar.td*avar.omega) - M_PI)/avar.omega;
-
-	avar.Cdef = 1.0 - exp(-avar.tmax/avar.td)*(cos(avar.omega*avar.tmax)+
-		1/(avar.omega*avar.td)*sin(avar.omega*avar.tmax));
-	avar.ycoef = 0.5*avar.Cdef*(avar.Cf/(avar.Ck*avar.Cb))*(avar.rhog*avar.L)/fvar.sig;
-
-	//cout << avar.ycoef << "  " << avar.Cdef << "  " << avar.tmax << "  " << endl;
-}
 
 
 #endif

--- a/src/IPT.h
+++ b/src/IPT.h
@@ -7,86 +7,1203 @@
 #include "Var.h"
 #include "Containment.h"
 #include "IO.h"
+#include "Aero.h"
 
+/* Particle tracking functions */
 namespace IPT
 {
-    void Terminate_Particle(SIM& svar, MESH const& cells, vector<IPTPart> const& time_record, size_t const& ii,
-        IPTPart& pnp1, vector<SURF>& surface_data )
+    
+
+    namespace ASCII
+    {
+        string Get_Variables(int const& offset)
+        {
+            string variables;
+                
+            if(offset == 1)
+                variables = "\"Y\", \"Z\"";
+            else if(offset == 2)
+                variables = "\"X\", \"Z\"";
+            else if (offset == 3)
+                variables = "\"X\", \"Y\"";
+            else
+                variables = "\"X\", \"Y\", \"Z\"";
+
+            variables += ", \"t\", \"dt\", \"v\", \"a\", \"ptID\", \"Cell_V\", \"Cell_Rho\", \"Cell_ID\"";
+            return variables;
+        }
+
+        string Cell_Variables(int const& offset)
+        {
+            string variables;
+                
+            if(offset == 1)
+                variables = "\"Y\", \"Z\"";
+            else if(offset == 2)
+                variables = "\"X\", \"Z\"";
+            else if (offset == 3)
+                variables = "\"X\", \"Y\"";
+            else
+                variables = "\"X\", \"Y\", \"Z\"";
+
+            return variables;
+        }
+
+
+        void Write_variables(ofstream& fp, int const& offset)
+        {
+            fp << "VARIABLES = " << Get_Variables(offset) << endl;
+        }
+
+        void Write_Scatter_Header(ofstream& fp, int const& offset)
+        {
+            fp << "TITLE =\"IPT particle scatter data\" \n";
+            Write_variables(fp, offset);
+            fp << "F=POINT" << endl;
+            fp << std::left << std::scientific << std::setprecision(6);
+        }
+
+        void Write_Streaks_Header(ofstream& fout, int const& offset)
+        {
+            fout << "TITLE = \"IPT Streaks\"\n";
+            Write_variables(fout, offset);
+        }
+
+        void Write_Cells_Header(ofstream& fout, int const& offset)
+        {
+            fout << "TITLE = \"IPT intersecting cells\"\n";
+
+            string variables;
+            if(offset == 1)
+                variables = "\"Y\", \"Z\"";
+            else if(offset == 2)
+                variables = "\"X\", \"Z\"";
+            else if (offset == 3)
+                variables = "\"X\", \"Y\"";
+            else
+                variables = "\"X\", \"Y\", \"Z\"";
+
+            fout << "VARIABLES= " << variables << endl;
+        }
+        
+        void Init_IPT_Files(SIM& svar)
+        {
+            string partf, cellf, streakf, surfacef;
+
+            partf = svar.output_prefix + "_IPT_scatter.dat";
+
+            streakf = svar.output_prefix + "_IPT_streaks.dat";
+
+            cellf = svar.output_prefix + "_IPT_cells.dat";
+
+            surfacef = svar.output_prefix + "_surface_impacts.dat";
+
+            if(svar.partout == 1)
+            {
+                if(svar.restart == 1)
+                {
+                    svar.partfile.open(partf,std::ios::app);
+                    if(!svar.partfile)
+                    {
+                        cout << "Couldn't open the IPT particle scatter output file." << endl;
+                        exit(-1);
+                    }
+                }
+                else
+                {
+                    svar.partfile.open(partf,std::ios::out);
+
+                    if(svar.partfile.is_open())
+                    {
+                        Write_Scatter_Header(svar.partfile, svar.offset_axis);
+                    }
+                    else
+                    {
+                        cout << "Couldn't open the IPT particle scatter output file." << endl;
+                        exit(-1);
+                    }
+                }
+            }
+
+            if(svar.streakout == 1)
+            {
+                if(svar.restart == 1)
+                {
+                    svar.streakfile.open(streakf,std::ios::app);
+                    if(!svar.streakfile)
+                    {
+                        cout << "Couldn't open the IPT streaks output file." << endl;
+                        exit(-1);
+                    }
+                }
+                else
+                {
+                    svar.streakfile.open(streakf,std::ios::out);
+
+                    if(svar.streakfile.is_open())
+                    {
+                        Write_Streaks_Header(svar.streakfile, svar.offset_axis);
+                    }
+                    else
+                    {
+                        cout << "Couldn't open the IPT streaks output file." << endl;
+                        exit(-1);
+                    }
+                }
+            }
+
+            if(svar.cellsout == 1)
+            {
+                if(svar.restart == 1)
+                {
+                    svar.cellfile.open(cellf,std::ios::app);
+                    if(!svar.cellfile)
+                    {
+                        cout << "Couldn't open the IPT cell intersection output file." << endl;
+                        exit(-1);
+                    }
+                }
+                else
+                {
+                    svar.cellfile.open(cellf,std::ios::out);
+
+                    if(svar.cellfile.is_open())
+                    {
+                        Write_Cells_Header(svar.cellfile, svar.offset_axis);
+                    }
+                    else
+                    {
+                        cout << "Couldn't open the IPT cell intersection output file." << endl;
+                        exit(-1);
+                    }
+                }
+            }
+        }
+
+        void Write_Point(ofstream& fp, real const& scale, IPTPart const& pnp1)
+        {
+            const static uint width = 15;
+
+            for(uint dim = 0; dim < SIMDIM; ++dim)
+                fp << setw(width) << pnp1.xi[dim]/scale;
+
+            fp << setw(width) << pnp1.t; 
+
+            fp << setw(width) << pnp1.dt; 
+            
+            fp << setw(width) << pnp1.v.norm(); 
+
+            fp << setw(width) << pnp1.acc; 
+
+            fp << setw(width) << pnp1.partID;
+
+            fp << setw(width) << pnp1.cellV.norm();
+
+            fp << setw(width) << pnp1.cellRho;
+            fp << setw(width) << pnp1.cellID << "\n"; 
+        }
+
+        void Write_Timestep(ofstream& fp, SIM const& svar, IPTState const& pnp1)
+        {
+            fp <<  "ZONE T=\"" << "IPT scatter data" << "\"";
+            fp <<", I=" << pnp1.size() << ", F=POINT" <<", STRANDID=5, SOLUTIONTIME=" << svar.t  << "\n";
+            fp << std::left << std::scientific << std::setprecision(6);
+            
+            for (size_t ii = 0; ii < pnp1.size(); ++ii)
+            {
+                Write_Point(fp, svar.scale, pnp1[ii]);
+            }
+            fp << std::flush;
+        }
+
+        void Write_Streaks( SIM& svar, IPTState const& t_pnp1)
+        {
+            ofstream& fp = svar.streakfile;
+            if(!fp.is_open())
+            {
+                cout << "The streak output file is not open. Cannot write." << endl;
+                exit(-1);
+            }
+            
+            size_t nTimes = t_pnp1.size();
+            size_t time = 0;
+            
+            fp <<  "ZONE T=\"" << "Particle " << t_pnp1[0].partID << "\"";
+            
+            fp <<", I=" << nTimes << ", J=1, K=1, DATAPACKING=POINT"<< "\n";
+
+            fp << std::left << std::scientific << std::setprecision(6);
+
+            for (time = 0; time < nTimes; ++time)
+            { /* Inner loop to write the times of the particle */
+                Write_Point(fp, svar.scale, t_pnp1[time]);
+            }
+        }
+
+
+        void Write_Cells(SIM& svar, MESH const& cells, IPTState const& t_pnp1, int32_t const& totalNumFaceNodes, 
+            vector<StateVecD> const& usedVerts, vector<int32_t> const& cellIndexes,
+            vector<vector<int32_t>> const& faces, vector<int32_t> const& left, vector<int32_t> const& right)
+        {
+            ofstream& fout = svar.cellfile;
+
+            if(!fout.is_open())
+            {
+                cout << "Couldn't open the cell intersection output file." << endl;
+                exit(-1);
+            }
+
+            fout << "ZONE T=\"particle " << t_pnp1[0].partID << " intersecting cells\"" << endl;
+            #if SIMDIM == 3
+            fout << "ZONETYPE=FEPOLYHEDRON" << endl;
+            #else
+            fout << "ZONETYPE=FEPOLYGON" << endl;
+            #endif
+            fout << "NODES=" << usedVerts.size() << " ELEMENTS=" << cellIndexes.size() << 
+                    " FACES=" << faces.size() << endl;
+            fout << "TotalNumFaceNodes=" << totalNumFaceNodes << endl;
+            fout << "NumConnectedBoundaryFaces=0 TotalNumBoundaryConnections=0" << endl;
+
+            size_t w = 15;
+            size_t preci = 6;
+            fout << std::left << std::scientific << std::setprecision(preci);
+
+            size_t newl = 0;
+            fout << std::setw(1);
+            for(size_t DIM = 0; DIM < SIMDIM; ++DIM)
+            {
+                for(size_t ii = 0; ii < usedVerts.size(); ++ii)
+                {
+                    fout << std::setw(w) << usedVerts[ii][DIM];
+                    newl++;
+
+                    if(newl>4)
+                    {
+                        fout << endl;
+                        fout << " ";
+                        newl=0;
+                    }
+                }
+            }
+            fout << endl;
+
+            fout << std::left << std::fixed;
+            w = 9;
+            /*Inform of how many vertices in each face*/
+            fout << "#node count per face" << endl;
+            newl = 0;
+            for (size_t ii = 0; ii < faces.size(); ++ii)
+            {
+                fout << std::setw(w) << faces[ii].size();
+                newl++;
+
+                if(newl>4)
+                {
+                    fout << endl;
+                    newl=0;
+                }
+            }
+            fout << endl;
+            /*Write the face data*/
+            fout << "#face nodes" << endl;
+            for (size_t ii = 0; ii < faces.size(); ++ii)
+            {
+                for(auto const& vertex:faces[ii])
+                {	/*Write face vertex indexes*/
+                    fout << std::setw(w) << vertex;
+                    // if (vertex > fdata.nPnts)
+                    // {
+                    // 	cout << "Trying to write a vertex outside of the number of points." << endl;
+                    // }
+                }
+                fout << endl;
+            }
+
+            /*Write face left and right*/
+            newl = 0;
+            fout << "#left elements" << endl;
+            for (size_t ii = 0; ii < left.size(); ++ii)
+            {
+                fout << std::setw(w) << left[ii] ;
+                newl++;
+
+                if(newl>4)
+                {
+                    fout << endl;
+                    newl=0;
+                }
+            }
+            fout << endl;
+
+            newl = 0;
+            fout << "#right elements" << endl;
+            for (size_t ii = 0; ii < right.size(); ++ii)
+            {
+                fout << std::setw(w) << right[ii] ;
+                newl++;
+
+                if(newl>4)
+                {
+                    fout << endl;
+                    newl=0;
+                }
+            }
+
+            fout.close();
+        }
+
+        void Write_Impacts(SIM const& svar, FLUID const& fvar, MESH const& cells, 
+                    vector<SURF> const& surfaces_to_write, vector<string> const& names, 
+                    vector<vector<real>> const& beta_data, vector<vector<StateVecD>> const& usedVerts, 
+                    vector<vector<vector<size_t>>> const& faces)
+        {
+            string file = svar.output_prefix;
+            file.append("_surface_impacts.dat");
+
+            ofstream fout(file);
+
+            if(!fout.is_open())
+            {
+                cout << "Couldn't open the surface impact output file." << endl;
+                exit(-1);
+            }
+
+            fout << "TITLE=\"Surface collision metrics\"\n";
+            #if SIMDIM == 3
+            fout << "VARIABLES= \"X\" \"Y\" \"Z\" \"Number of Impacts\" \"beta\" \"average area\"\n";
+            #else
+            fout << "VARIABLES= \"X\" \"Z\" \"Number of Impacts\" \"beta\" \"average area\"\n";
+            #endif
+            for(size_t ii = 0; ii < faces.size(); ++ii)
+            {
+                fout << "ZONE T=\"" << names[ii] << "\"\n";
+                fout << "N=" << usedVerts[ii].size() << ", E=" << faces[ii].size();
+                #if SIMDIM == 3
+                fout << ", F=FEBLOCK ET=QUADRILATERAL, VARLOCATION=([1-3]=NODAL,[4-7]=CELLCENTERED)\n\n";
+                #else
+                fout << ", F=FELINESEG, VARLOCATION=([1-2]=NODAL,[3-6]=CELLCENTERED)\n\n";
+                #endif
+                
+                size_t w = 15;
+                size_t preci = 6;
+                fout << std::left << std::scientific << std::setprecision(preci);
+
+                size_t newl = 0;
+                fout << std::setw(1);
+                for(size_t DIM = 0; DIM < SIMDIM; ++DIM)
+                {
+                    for(size_t jj = 0; jj < usedVerts[ii].size(); ++jj)
+                    {
+                        fout << std::setw(w) << usedVerts[ii][jj][DIM];
+                        newl++;
+
+                        if(newl>4)
+                        {
+                            fout << endl;
+                            fout << " ";
+                            newl=0;
+                        }
+                    }
+                }
+                fout << endl << endl;
+
+                /* Variable data goes here */
+                fout << "#face impact count" << endl;
+                for(size_t jj = 0; jj < surfaces_to_write[ii].face_count.size(); ++jj)
+                {
+                    fout << std::setw(w) << surfaces_to_write[ii].face_count[jj];
+                    newl++;
+
+                    if(newl>4)
+                    {
+                        fout << endl;
+                        fout << " ";
+                        newl=0;
+                    }
+                }
+                fout << endl << endl;
+
+                fout << "#face beta value" << endl; 
+                for(size_t jj = 0; jj < surfaces_to_write[ii].face_beta.size(); ++jj)
+                {
+                    fout << std::setw(w) << surfaces_to_write[ii].face_beta[jj];
+                    newl++;
+
+                    if(newl>4)
+                    {
+                        fout << endl;
+                        fout << " ";
+                        newl=0;
+                    }
+                }
+                fout << endl << endl;
+
+                fout << "#face area value" << endl;
+                for(size_t jj = 0; jj < surfaces_to_write[ii].face_area.size(); ++jj)
+                {
+                    fout << std::setw(w) << surfaces_to_write[ii].face_area[jj];
+                    newl++;
+
+                    if(newl>4)
+                    {
+                        fout << endl;
+                        fout << " ";
+                        newl=0;
+                    }
+                }
+                fout << endl << endl;
+
+
+                /*Write the face data*/
+                fout << "#face nodes" << endl;
+                for (size_t jj = 0; jj < faces[ii].size(); ++jj)
+                {
+                    for(auto const& vertex:faces[ii][jj])
+                    {	/*Write face vertex indexes*/
+                        fout << std::setw(w) << vertex;
+                        // if (vertex > fdata.nPnts)
+                        // {
+                        // 	cout << "Trying to write a vertex outside of the number of points." << endl;
+                        // }
+                    }
+
+                    if(faces[ii][jj].size() == 3)
+                        fout << std::setw(w) << faces[ii][jj].back();
+
+                    fout << endl;
+                }
+            }
+            fout.close();
+        }
+    }
+
+    namespace BINARY
+    {
+        string Get_Variables(int const& offset)
+        {
+            string variables;
+                
+            if(offset == 1)
+                variables = "Y,Z";
+            else if(offset == 2)
+                variables = "X,Z";
+            else if (offset == 3)
+                variables = "X,Y";
+            else
+                variables = "X,Y,Z";
+
+            variables += 
+            ",t,dt,v,a,ptID,Cell_V,Cell_Rho,Cell_ID";
+            return variables;
+        }
+
+        string Cell_Variables(int const& offset)
+        {
+            string variables;
+                
+            if(offset == 1)
+                variables = "Y,Z";
+            else if(offset == 2)
+                variables = "X,Z";
+            else if (offset == 3)
+                variables = "X,Y";
+            else
+                variables = "X,Y,Z";
+
+            return variables;
+        }
+
+        void Open_File(string const& file, string const& title, string const& var, void* &fileHandle)
+        {
+            if(tecFileWriterOpen(file.c_str(),title.c_str(),var.c_str(),1,0,1,NULL,&fileHandle))
+            {
+                cout << "Failed to open " << file << endl;
+                exit(-1);
+            }
+            #ifdef DEBUG
+            if(tecFileSetDiagnosticsLevel(fileHandle, 1))
+            {
+                cerr << "Failed to set debug option for output file: " << file << endl;
+                exit(-1);
+            }
+            #endif
+        }
+
+        void Init_IPT_Files(SIM& svar)
+        {
+            string partf, cellf, streakf, surfacef;
+
+            partf = svar.output_prefix + "_IPT_scatter.szplt";
+
+            streakf = svar.output_prefix + "_streaks.szplt";
+
+            cellf = svar.output_prefix + "_cells.szplt";
+
+            surfacef = svar.output_prefix + "_surface_impacts.szplt";
+
+            // int32_t fileType   = 0; /*0 = Full, 1 = Grid, 2 = Solution*/
+            // int32_t fileFormat = 1; // 0 == PLT, 1 == SZPLT
+            string part_variables = Get_Variables(svar.offset_axis);
+            string cell_variables = Cell_Variables(svar.offset_axis);
+
+            #if FOD == 1
+                int32_t realType = 2;
+            #else
+                int32_t realType = 1;
+            #endif
+
+            #if SIMDIM == 3
+            vector<int32_t> varTypes = {realType,realType,realType,realType,3,realType,realType,3};
+            #else
+            vector<int32_t> varTypes = {realType,realType,realType,realType,3,realType,realType,3};
+            #endif
+
+            if(svar.partout == 1)
+            {
+                string title = "IPT particle scatter data";
+                Open_File(partf,title,part_variables,svar.partHandle);
+            }
+
+            if(svar.streakout == 1)
+            {
+                string title = "IPT particle streak data";
+                Open_File(streakf,title,part_variables,svar.streakHandle);
+            }
+
+            if(svar.cellsout == 1)
+            {
+                string title = "IPT particle cell intersection data";
+                Open_File(cellf,title,cell_variables,svar.cellHandle);
+            }
+        }
+
+        void Write_Point(SIM const& svar, IPTPart const& pnp1)
+        {
+            int64_t const size = 1;
+
+            double solTime = pnp1.t;     
+            int32_t outputZone;
+
+            #if FOD == 1
+                int32_t realType = 2;
+            #else
+                int32_t realType = 1;
+            #endif
+
+            #if SIMDIM == 3
+            vector<int32_t> varTypes = {realType,realType,realType,realType,3,realType,realType,3};
+            #else
+            vector<int32_t> varTypes = {realType,realType,realType,3,realType,realType,3};
+            #endif
+            vector<int32_t> shareVarFromZone(varTypes.size(),0);
+            vector<int32_t> valueLocation(varTypes.size(),1);
+            vector<int32_t> passiveVarList(varTypes.size(),0);
+ 
+            string group = "IPT Particle " + std::to_string(pnp1.partID) + " scatter data";
+            if(tecZoneCreateIJK(svar.partHandle,group.c_str(),size,1,1,&varTypes[0],
+                &shareVarFromZone[0],&valueLocation[0],&passiveVarList[0],0,0,0,&outputZone))
+            {
+                cerr << "Failed to create IJK zone." << endl;
+                exit(-1);
+            }
+
+            if(tecZoneSetUnsteadyOptions(svar.partHandle, outputZone, solTime, 4))
+            {
+                cerr << "Failed to add unsteady options." << endl;
+                exit(-1);
+            }
+
+            vector<real> x(size);
+            int32_t var = 1;
+
+            for(uint dim = 0; dim < SIMDIM; ++dim)
+            {
+                x[0] = pnp1.xi(dim)/svar.scale;
+
+                string name = "position coordinate ";
+                name.append(std::to_string(dim));
+                Write_Real_Vector(svar.partHandle, outputZone, var, size, x, name);
+            }
+
+            vector<real> t(size);
+            vector<real> dt(size);
+            vector<real> vel(size);
+            vector<real> acc(size);
+            vector<real> cVel(size);
+            vector<real> cRho(size);
+            vector<int> pID(size);
+            vector<int> cID(size);
+
+            t[0] = pnp1.t;
+            dt[0] = pnp1.dt;
+            vel[0] = pnp1.v.norm();
+            acc[0] = pnp1.acc;
+            cVel[0] = pnp1.cellV.norm();
+            cRho[0] = pnp1.cellRho;
+            pID[0] = pnp1.partID;
+            cID[0] = pnp1.cellID;
+
+            Write_Real_Vector(svar.partHandle, outputZone, var, size, t, "particle time");
+            Write_Real_Vector(svar.partHandle, outputZone, var, size, dt, "timestep");
+            Write_Real_Vector(svar.partHandle, outputZone, var, size, vel, "velocity magnitude");
+            Write_Real_Vector(svar.partHandle, outputZone, var, size, acc, "acceleration magnitude");
+            Write_Int_Vector(svar.partHandle, outputZone, var, size, pID, "particle ID");
+			Write_Real_Vector(svar.partHandle, outputZone, var, size, cVel, "cell velocity");
+			Write_Real_Vector(svar.partHandle, outputZone, var, size, cRho, "cell density");
+			Write_Int_Vector(svar.partHandle, outputZone, var, size, cID, "cell ID");
+
+            if(tecFileWriterFlush(svar.partHandle,0,NULL))
+            {
+                cout << "Failed to flush data. Retrying..." << endl;
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                // retry the flush
+                if(tecFileWriterFlush(svar.partHandle,0,NULL))
+                {
+                    cerr << "Failed to flush data to particle file" << endl;
+                    exit(-1);
+                }
+            }
+        }
+
+        void Write_State(SIM const& svar, IPTState const& pnp1, string const& zoneName, void* &fileHandle)
+        {
+            int64_t const size = pnp1.size();
+
+            double solTime = svar.t;     
+            int32_t outputZone;
+
+            #if FOD == 1
+                int32_t realType = 2;
+            #else
+                int32_t realType = 1;
+            #endif
+
+            #if SIMDIM == 3    
+            // variables =  "X,Y,Z,t,dt,v,a,ptID,Cell_V,Cell_Rho,Cell_ID"
+            vector<int32_t> varTypes = 
+            {realType,realType,realType,realType,realType,realType,realType,3,realType,realType,3};
+            #else
+            // variables =  "X,Z,t,dt,v,a,ptID,Cell_V,Cell_Rho,Cell_ID"
+            vector<int32_t> varTypes = 
+                {realType,realType,realType,realType,realType,realType,3,realType,realType,3};
+            #endif
+            vector<int32_t> shareVarFromZone(varTypes.size(),0);
+            vector<int32_t> valueLocation(varTypes.size(),1);
+            vector<int32_t> passiveVarList(varTypes.size(),0);
+ 
+            if(tecZoneCreateIJK(fileHandle,zoneName.c_str(),size,1,1,&varTypes[0],
+                &shareVarFromZone[0],&valueLocation[0],&passiveVarList[0],0,0,0,&outputZone))
+            {
+                cerr << "Failed to create IJK zone." << endl;
+                exit(-1);
+            }
+
+            if(tecZoneSetUnsteadyOptions(fileHandle, outputZone, solTime, 6))
+            {
+                cerr << "Failed to add unsteady options." << endl;
+                exit(-1);
+            }
+
+            vector<real> x(size);
+            int32_t var = 1;
+
+            for(uint dim = 0; dim < SIMDIM; ++dim)
+            {
+                #pragma omp parallel for
+                for(uint ii = 0; ii < size; ++ii)
+                    x[ii] = pnp1[ii].xi(dim)/svar.scale;
+
+                string name = "position coordinate " + std::to_string(dim);
+                Write_Real_Vector(fileHandle, outputZone, var, size, x, name);
+            }
+
+            vector<real> t(size);
+            vector<real> dt(size);
+            vector<real> vel(size);
+            vector<real> acc(size);
+            vector<real> cVel(size);
+            vector<real> cRho(size);
+            vector<int> pID(size);
+            vector<int> cID(size);
+
+            for (int ii = 0; ii < size; ++ii)
+            {
+                t[ii] = pnp1[ii].t;
+                dt[ii] = pnp1[ii].dt;
+                vel[ii] = pnp1[ii].v.norm();
+                acc[ii] = pnp1[ii].acc;
+                cVel[ii] = pnp1[ii].cellV.norm();
+                cRho[ii] = pnp1[ii].cellRho;
+                pID[ii] = pnp1[ii].partID;
+                cID[ii] = pnp1[ii].cellID;
+            }
+
+            Write_Real_Vector(fileHandle, outputZone, var, size, t, "particle time");
+            Write_Real_Vector(fileHandle, outputZone, var, size, dt, "timestep");
+            Write_Real_Vector(fileHandle, outputZone, var, size, vel, "velocity magnitude");
+            Write_Real_Vector(fileHandle, outputZone, var, size, acc, "acceleration magnitude");
+            Write_Int_Vector(fileHandle, outputZone, var, size, pID, "particle ID");
+			Write_Real_Vector(fileHandle, outputZone, var, size, cVel, "cell velocity");
+			Write_Real_Vector(fileHandle, outputZone, var, size, cRho, "cell density");
+			Write_Int_Vector(fileHandle, outputZone, var, size, cID, "cell ID");
+
+        }
+
+        void Write_Cells(SIM& svar, MESH const& cells, IPTState const& pnp1, int32_t const& totalNumFaceNodes, 
+            vector<StateVecD> const& usedVerts, vector<int32_t> const& cellIndexes,
+            vector<vector<int32_t>> const& faces, vector<int32_t> const& left, vector<int32_t> const& right)
+        {
+            // int64_t const size = pnp1.size();
+
+            double solTime = svar.t;     
+            int32_t outputZone;
+
+            #if FOD == 1
+                int32_t realType = 2;
+            #else
+                int32_t realType = 1;
+            #endif
+
+            #if SIMDIM == 3
+            vector<int32_t> varTypes = {realType,realType,realType,realType,3,realType,realType,3};
+            #else
+            vector<int32_t> varTypes = {realType,realType,realType,3,realType,realType,3};
+            #endif
+            vector<int32_t> shareVarFromZone(varTypes.size(),0);
+            vector<int32_t> valueLocation(varTypes.size(),1);
+            vector<int32_t> passiveVarList(varTypes.size(),0);
+
+            #if SIMDIM == 3
+            int32_t zoneType = 7; /* FE Polyhedron */
+            #else
+            int32_t zoneType = 6; /* FE Polygon */
+            #endif
+            int32_t nNodes = usedVerts.size();
+            int32_t nFaces = faces.size();
+            int32_t nCells = cellIndexes.size();
+
+            string group = "IPT cell intersection data";
+            if(tecZoneCreatePoly(svar.cellHandle,group.c_str(),zoneType,nNodes,nFaces,nCells,
+                totalNumFaceNodes,&varTypes[0],&shareVarFromZone[0],&valueLocation[0],
+                &passiveVarList[0],0,0,0,&outputZone))
+            {
+                cerr << "Failed to create polyhedral/polygonal zone." << endl;
+                exit(-1);
+            }
+
+            if(tecZoneSetUnsteadyOptions(svar.cellHandle, outputZone, solTime, 7))
+            {
+                cerr << "Failed to add unsteady options." << endl;
+                exit(-1);
+            }
+
+            vector<real> x(nNodes);
+            int32_t var = 1;
+
+            for(uint dim = 0; dim < SIMDIM; ++dim)
+            {
+                #pragma omp parallel for
+                for(int32_t ii = 0; ii < nNodes; ++ii)
+                    x[ii] = usedVerts[ii][dim];
+
+                string name = "position coordinate " + std::to_string(dim);
+                Write_Real_Vector(svar.cellHandle, outputZone, var, nNodes, x, name);
+            }
+
+            vector<int32_t> faceCounts(faces.size());
+            vector<int32_t> faceNodes(totalNumFaceNodes);
+            size_t jj = 0;
+            /*Inform of how many vertices in each face*/
+            for (size_t ii = 0; ii < faces.size(); ++ii)
+            {
+                faceCounts[ii] =  faces[ii].size();
+                for(auto const& vertex:faces[ii])
+                {	/*Write face vertex indexes*/
+                    faceNodes[jj] = vertex;
+                    jj++;
+                }
+            }
+
+            tecZoneWritePolyFaces32(svar.cellHandle,outputZone,0,nFaces,&faceCounts[0],
+                            &faceNodes[0],&left[0],&right[0],1);
+        }
+    }
+
+    void Get_Intersection_Data(SIM const& svar, MESH const& cells, IPTState const& t_pnp1,
+        vector<StateVecD>& usedVerts, vector<int>& cellIndexes, vector<vector<int32_t>>& faces, 
+        vector<int32_t>& left, vector<int32_t>& right,  int32_t& totalNumFaceNodes)
+    {
+        size_t nTimes = t_pnp1.size();
+        size_t time = 0;
+
+
+        vector<int32_t> vertIndexes;
+        vector<int32_t> faceIndexes;
+
+        /* Get cell properties for the intersected cells (delete duplicates later)*/
+        for (time = 0; time < nTimes; ++time)
+        {
+            int cellID = t_pnp1[time].cellID;
+            
+            /* Find how many vertices the cell has */
+            for(size_t ii = 0; ii < cells.cFaces.size(); ++ii)
+                vertIndexes.insert(vertIndexes.end(), 
+                cells.faces[cells.cFaces[cellID][ii]].begin(), cells.faces[cells.cFaces[cellID][ii]].end());
+
+            faceIndexes.insert(faceIndexes.end(), cells.cFaces[cellID].begin(), cells.cFaces[cellID].end());
+            cellIndexes.emplace_back(cellID);
+        }
+
+        /* Delete repeats of vertex mentions*/
+        std::sort(vertIndexes.begin(),vertIndexes.end());
+        vertIndexes.erase( std::unique( vertIndexes.begin(), vertIndexes.end()), vertIndexes.end() );
+
+        std::sort(faceIndexes.begin(),faceIndexes.end());
+        faceIndexes.erase( std::unique( faceIndexes.begin(), faceIndexes.end()), faceIndexes.end() );
+
+        for(size_t const& vert : vertIndexes)
+        {
+            usedVerts.emplace_back(cells.verts[vert]);
+        }
+
+        /* Get faces properties used in the cell */
+        for(size_t const& face: faceIndexes )
+        {
+            faces.emplace_back(cells.faces[face].begin(),cells.faces[face].end());
+            left.emplace_back(cells.leftright[face].first);
+            right.emplace_back(cells.leftright[face].second);
+        }
+
+        /* Go through the faces indexes, finding the appropriate index to change it to */
+        for(vector<int32_t>& face : faces)
+        {
+            for(int32_t& vert : face)
+            {
+                vector<int32_t>::iterator index = std::find(vertIndexes.begin(), vertIndexes.end(), vert);
+                if(index != vertIndexes.end())
+                {
+                    vert = index - vertIndexes.begin() + 1 ;
+                }
+                else
+                {
+                    cout << "Couldn't find the vertex used in the prepared list." << endl;
+                    exit(-1);
+                }                
+            }
+            totalNumFaceNodes += face.size();
+        }
+
+        /* Find the cell used and change it's index */
+        for(int& leftCell:left)
+        {
+            vector<int>::iterator index = std::find(cellIndexes.begin(), cellIndexes.end(), leftCell);
+            if(index != cellIndexes.end())
+            {
+                leftCell = (index - cellIndexes.begin())+1;
+            }
+            else
+            {   /* Cell isn't intersected, so it won't be drawn. Boundary face. */
+                leftCell = 0;
+            } 
+        }
+
+        for(int& rightCell:right)
+        {
+            vector<int>::iterator index = std::find(cellIndexes.begin(), cellIndexes.end(), rightCell);
+            if(index != cellIndexes.end())
+            {
+                rightCell = index - cellIndexes.begin() + 1;
+            }
+            else
+            {   /* Cell isn't intersected, so it won't be drawn. Boundary face. */
+                rightCell = 0;
+            }
+        }
+    }
+
+    void Get_Impact_Data(SIM const& svar, FLUID const& fvar, MESH const& cells, 
+                vector<SURF> const& surfs, vector<vector<real>> const& beta_data,
+                vector<SURF>& surfaces_to_write, vector<string>& names, 
+                vector<vector<StateVecD>>& usedVerts, vector<vector<vector<size_t>>>& faces)
+    {
+        // uint nSurf = svar.markers.size();
+        uint nSurf = 0;
+        vector<int> marks;
+        // vector<string> names;
+        // vector<SURF> surfaces_to_write;
+        for(size_t ii = 0; ii < surfs.size(); ii++)
+        {
+            if(surfs[ii].output == 1)
+            {
+                marks.emplace_back(svar.markers[ii]);
+                names.emplace_back(svar.bnames[ii]);
+                surfaces_to_write.emplace_back(surfs[ii]);
+            }
+            nSurf += surfs[ii].output;
+        }
+
+        nSurf = 0;
+        for(size_t ii = 0; ii < surfs.size(); ii++)
+        {
+            if(surfs[ii].output == 1)
+            {
+                surfaces_to_write[nSurf].face_count = surfs[ii].face_count;
+                surfaces_to_write[nSurf].face_beta = surfs[ii].face_beta;
+                surfaces_to_write[nSurf].face_area = surfs[ii].face_area;
+            }
+            nSurf += surfs[ii].output;
+        }
+
+        faces =  vector<vector<vector<size_t>>>(nSurf);
+        vector<std::pair<size_t,int>> smarkers = cells.smarkers;
+
+        vector<vector<size_t>> vertIndexes(nSurf);
+        usedVerts = vector<vector<StateVecD>>(nSurf);
+        
+        /* Do I need to sort the markers? */
+        std::sort(smarkers.begin(), smarkers.end(),
+        [](std::pair<size_t,int> const& p1, std::pair<size_t,int> const& p2){return p1.second > p2.second;});
+
+        for(size_t ii = 0; ii < surfaces_to_write.size(); ++ii)
+        {
+            for(size_t jj = 0; jj < surfaces_to_write[ii].faceIDs.size(); ++jj )
+            {
+                size_t faceID = surfaces_to_write[ii].faceIDs[jj];
+                faces[ii].emplace_back(cells.faces[faceID]);
+            }
+        
+            /* Get the vertex indexes, delete duplicates, reorder, and recast the face indexes */
+            for (vector<size_t> const& face : faces[ii])
+                vertIndexes[ii].insert(vertIndexes[ii].end(), face.begin(), face.end());
+            
+
+            std::sort(vertIndexes[ii].begin(),vertIndexes[ii].end());
+            vertIndexes[ii].erase(std::unique( vertIndexes[ii].begin(), vertIndexes[ii].end()), vertIndexes[ii].end() );
+
+            for(size_t const& vert : vertIndexes[ii])
+                usedVerts[ii].emplace_back(cells.verts[vert]);
+        
+
+            for(vector<size_t>& face : faces[ii])
+            {
+                for(size_t& vert : face)
+                {
+                    vector<size_t>::iterator index = std::find(vertIndexes[ii].begin(), vertIndexes[ii].end(), vert);
+                    if(index != vertIndexes[ii].end())
+                    {
+                        vert = index - vertIndexes[ii].begin() + 1 ;
+                    }
+                    else
+                    {
+                        cout << "Couldn't find the vertex used in the prepared list." << endl;
+                        exit(-1);
+                    }                
+                }
+            }
+        }    
+    }  
+    
+    void Init_IPT_Files(SIM& svar)
+    {
+        if(svar.out_encoding == 0)
+            ASCII::Init_IPT_Files(svar);
+        else
+            BINARY::Init_IPT_Files(svar);
+    }
+
+    void Write_Point(SIM& svar, IPTPart& pnp1)
+    {
+        if(svar.out_encoding == 0)
+            ASCII::Write_Point(svar.partfile, svar.scale, pnp1);
+        else
+            BINARY::Write_Point(svar,pnp1);
+
+    }
+
+    void Write_Data(SIM& svar, MESH& cells, vector<IPTState>& time_record)
+    {
+        if(svar.partout == 1)
+        {
+            // for(size_t ii = 0; ii < time_record.size(); ii++)
+            // {
+            //     if(svar.out_encoding == 0)
+            //         ASCII::Write_Timestep(svar.partfile,svar,time_record[ii]);
+            //     else
+            //         BINARY::
+            // }
+        }
+        if(svar.streakout == 1)
+        {
+            for(size_t ii = 0; ii < time_record.size(); ii++)
+            {
+                if(!time_record[ii].empty())
+                {
+                    if(svar.out_encoding == 0)
+                        ASCII::Write_Streaks(svar,time_record[ii]);
+                    else
+                    {
+                        string zone = "IPT Particle" + std::to_string(time_record[ii][0].partID) + " Streak";
+                        BINARY::Write_State(svar,time_record[ii],zone,svar.streakHandle);
+                    }
+                }
+            }
+
+            if(!time_record.empty())
+            {
+                if(svar.out_encoding == 0)
+                    svar.streakfile << std::flush;
+                else
+                {
+                
+                    if(tecFileWriterFlush(svar.streakHandle,0,NULL))
+                    {
+                        cout << "Failed to flush data. Retrying..." << endl;
+                        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                        // retry the flush
+                        if(tecFileWriterFlush(svar.streakHandle,0,NULL))
+                        {
+                            cerr << "Failed to flush data to streak file" << endl;
+                            exit(-1);
+                        }
+                    }
+                }
+            }
+        }
+        if(svar.cellsout == 1)
+        {
+            for(size_t ii = 0; ii < time_record.size(); ii++)
+            {
+                if(!time_record[ii].empty())
+                {
+                    vector<StateVecD> usedVerts;
+                    vector<int32_t> cellIndexes, left, right;
+                    vector<vector<int32_t>> faces;
+                    int32_t totalNumFaceNodes = 0;
+                    Get_Intersection_Data(svar, cells, time_record[ii], usedVerts, cellIndexes, faces, 
+                                        left, right, totalNumFaceNodes);
+                    if(svar.out_encoding == 0)
+                    {
+                        ASCII::Write_Cells(svar,cells,time_record[ii],totalNumFaceNodes,usedVerts,
+                                        cellIndexes,faces,left, right);
+                    }
+                    else
+                    {
+                        BINARY::Write_Cells(svar,cells,time_record[ii],totalNumFaceNodes,usedVerts,
+                                        cellIndexes,faces,left, right);
+                    }
+                }
+            }
+
+            if(!time_record.empty())
+            {
+                if(svar.out_encoding == 0)
+                    svar.cellfile << std::flush;
+                else
+                {
+                    if(tecFileWriterFlush(svar.cellHandle,0,NULL))
+                    {
+                        cout << "Failed to flush data. Retrying..." << endl;
+                        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                        // retry the flush
+                        if(tecFileWriterFlush(svar.cellHandle,0,NULL))
+                        {
+                            cerr << "Failed to flush data to cell intersection file" << endl;
+                            exit(-1);
+                        }
+                    }
+                }
+            }
+        }
+
+        if(!time_record.empty())
+            time_record.clear();
+    } 
+
+    void Terminate_Particle(SIM& svar, MESH const& cells, vector<IPTPart>& time_record, size_t const& ii,
+        IPTPart& pnp1, vector<SURF>& surface_data, vector<IPTState>& iptdata)
     {
         pnp1.going = 0;
 
+        if(pnp1.failed != 1)
+            time_record.emplace_back(pnp1);
+
         // cout << "Particle " << pnp1.partID << " stopped iterating"; 
-        if(svar.Asource != 0)
+        if(pnp1.cellID < 0)
         {
-            if(pnp1.cellID < 0)
+            /* Find which surface it has impacted  */
+            size_t const& face = pnp1.faceID;
+
+            auto const index = std::find_if(cells.smarkers.begin(), cells.smarkers.end(), 
+            [face](std::pair<size_t,int> const& p1){return p1.first == face;});
+
+            if(index != cells.smarkers.end())
             {
-                /* Find which surface it has impacted  */
-                size_t const& face = pnp1.faceID;
+                /* Find which surface to add to, and which face of that*/
+                auto const surface = std::find(svar.markers.begin(), svar.markers.end(), index->second);
 
-                auto const index = std::find_if(cells.smarkers.begin(), cells.smarkers.end(), 
-                [face](std::pair<size_t,int> const& p1){return p1.first == face;});
-
-                if(index != cells.smarkers.end())
+                if(surface != svar.markers.end())
                 {
-                    /* Find which surface to add to, and which face of that*/
-                    auto const surface = std::find(svar.markers.begin(), svar.markers.end(), index->second);
+                    size_t const surf = surface - svar.markers.begin();
 
-                    if(surface != svar.markers.end())
+                    // cout << " after hitting surface: " << svar.bnames[surf] << endl;
+                    #pragma omp critical
                     {
-                        size_t const surf = surface - svar.markers.begin();
+                        surface_data[surf].marker_count++;
+                        surface_data[surf].marker_pIDs.emplace_back(ii);
+                        surface_data[surf].end_pos.emplace_back(pnp1.xi);
+                        surface_data[surf].start_pos.emplace_back(time_record[0].xi);
+                    }
+                    auto const index2 =
+                        std::find(surface_data[surf].faceIDs.begin(), surface_data[surf].faceIDs.end(), face);
 
-                        // cout << " after hitting surface: " << svar.bnames[surf] << endl;
+                    if(index2 != surface_data[surf].faceIDs.end())
+                    {
+                        size_t fIndex = index2 - surface_data[surf].faceIDs.begin();
                         #pragma omp critical
                         {
-                            surface_data[surf].marker_count++;
-                            surface_data[surf].marker_pIDs.emplace_back(ii);
-                            surface_data[surf].end_pos.emplace_back(pnp1.xi);
-                            surface_data[surf].start_pos.emplace_back(time_record[0].xi);
-                        }
-                        auto const index2 =
-                            std::find(surface_data[surf].faceIDs.begin(), surface_data[surf].faceIDs.end(), face);
-
-                        if(index2 != surface_data[surf].faceIDs.end())
-                        {
-                            size_t fIndex = index2 - surface_data[surf].faceIDs.begin();
-                            #pragma omp critical
-                            {
-                                surface_data[surf].face_count[fIndex]++;
-                                surface_data[surf].impacted_face.emplace_back(fIndex);
-                            }
-                        }
-                        else
-                        {
-                            cout << "Couldn't find which face of the surface the particle impacted" << endl;
+                            surface_data[surf].face_count[fIndex]++;
+                            surface_data[surf].impacted_face.emplace_back(fIndex);
                         }
                     }
                     else
                     {
-                        cout << "Couldn't find which surface index for the marker." << endl;
+                        cout << "Couldn't find which face of the surface the particle impacted" << endl;
                     }
-                    
                 }
                 else
                 {
-                    cout << "Couldn't find which surface the particle impacted" << endl;
+                    cout << "Couldn't find which surface index for the marker." << endl;
                 }
-
                 
             }
             else
             {
-                // cout << " prematurely" << endl;
+                cout << "Couldn't find which surface the particle impacted" << endl;
             }
+
+            
         }
-        if(svar.streakout == 1)
+        else
         {
-            Write_ASCII_Streaks(svar,time_record,pnp1);
+            // cout << " prematurely" << endl;
         }
 
-        if(svar.cellsout == 1)
-        {
-            Write_ASCII_Cells(svar,cells,time_record);
-        }
+        iptdata.emplace_back(time_record);
+        // if(svar.streakout == 1)
+        // {
+        //     #pragma omp critical
+        //     {
+        //         Write_ASCII_Streaks(svar,time_record,pnp1);
+        //     }
+        // }
+
+        // if(svar.cellsout == 1)
+        // {
+        //     #pragma omp critical
+        //     {
+        //         Write_ASCII_Cells(svar,cells,time_record);
+        //     }
+        // }
     }
 
 
@@ -128,16 +1245,13 @@ namespace IPT
     }
 
     void Integrate(SIM& svar, FLUID const& fvar, AERO const& avar, MESH const& cells, size_t const& ii, 
-                            IPTPart& pnm1, IPTPart& pn, IPTPart& pnp1, vector<SURF>& marker_data)
+                            IPTPart& pnm1, IPTPart& pn, IPTPart& pnp1, vector<SURF>& marker_data, 
+                            vector<IPTState>& iptdata)
     {
         /* Do the first step */
         IPTState time_record;
         time_record.emplace_back(pnp1);
         ofstream partfile;
-        if(svar.partout == 1)
-        {
-
-        }
 
         /* Find intersecting face for np1 */
         // pnp1.faceV = pnp1.cellV; /* Start by guessing the face as the cell*/
@@ -183,19 +1297,19 @@ namespace IPT
         }
 
         if(svar.partout == 1)
-            Write_ASCII_Point(partfile, svar.scale, pnp1);
+            Write_Point(svar, pnp1);
 
         if (pnp1.going == 0 || pnp1.v.norm() > 1e3
             || (pnp1.xi - pn.xi).norm() > cells.maxlength )
         {
             pnp1.failed = 1;
-            Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data);
+            Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data, iptdata);
             #pragma omp atomic
                 svar.nFailed++;
         }
         else if (pnp1.cellID < 0 || pnp1.xi[0] > svar.max_x)
         {      
-            Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data);
+            Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data, iptdata);
             #pragma omp atomic
                 svar.nSuccess++;
         }
@@ -280,20 +1394,26 @@ namespace IPT
             }
 
             if(svar.partout == 1)
-                Write_ASCII_Point(partfile, svar.scale, pnp1);
+                Write_Point(svar, pnp1);
 
             if ( pnp1.going == 0 || pnp1.v.norm() > 1e3
                     || (pnp1.xi - pn.xi).norm() > cells.maxlength )
             {
+                if((pnp1.xi - pn.xi).norm() > cells.maxlength)
+                {
+                    cout << "Particle terminated because of max length" << endl;
+                    cout << (pnp1.xi - pn.xi).norm() << "  " << cells.maxlength << endl;
+                }
                 pnp1.failed = 1;
-                Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data);
+                Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data, iptdata);
                 #pragma omp atomic
                     svar.nFailed++;
                 break;
             }
             else if ( pnp1.cellID < 0 || pnp1.xi[0] > svar.max_x)
-            {      
-                Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data);
+            {    
+                cout << "Particle terminated because of a success" << endl;
+                Terminate_Particle(svar, cells, time_record, ii, pnp1, marker_data, iptdata);
                 #pragma omp atomic
                     svar.nSuccess++;
                 break;

--- a/src/Init.h
+++ b/src/Init.h
@@ -75,83 +75,174 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 	real rho = fvar.rho0*pow((press/fvar.B) + 1.0, 1.0/fvar.gam);
 
 /************** Create the boundary pn  *****************/ 	 
+	int nlevels = 3;
 	real step = svar.Pstep*svar.Bstep;
-	int Ny = ceil((svar.bound_box(1)+4*svar.Pstep)/step);	
-	int Nx = ceil((svar.bound_box(0)+4*svar.Pstep)/step);
-	#if (SIMDIM == 3)
-		int Nz = ceil(svar.bound_box(2)/step);
-	#endif
-	uint pID = 0;
 
+	int Nx = ceil((svar.bound_box[0]+2*(svar.Pstep - step))/step);
+	real dx = (svar.bound_box[0]+2*(svar.Pstep - step))/(Nx-1);
+
+	int Ny = ceil((svar.bound_box[1]+nlevels*dx+svar.Pstep)/step);
+	real dy = (svar.bound_box[1]+nlevels*dx+svar.Pstep)/(Ny-1);
+	
+	#if (SIMDIM == 3)
+		int Nz = ceil((svar.bound_box[2])/step);
+		real dz = (svar.bound_box[2])/(Nz-1);
+	#endif
+	
+	uint pID = 0;
 	/* Bcase == 0 -> no boundary */
 	if(svar.Bcase == 1) /*Rectangle*/
 	{	
+		if(svar.bound_solver == 1)
+		{
+			svar.bound_start[0] -= svar.Pstep;
+			svar.bound_start[1] -= svar.Pstep;
+
+			svar.bound_box[0] += 2*svar.Pstep;
+			svar.bound_box[1] += 2*svar.Pstep;
+
+			#if SIMDIM == 3
+			svar.bound_start[2] -= svar.Pstep;
+			svar.bound_box[2] += 2*svar.Pstep;
+			#endif
+		}
+
 		#if SIMDIM == 3
-			for(int j = 0; j <= Ny ; ++j) 
-			{
-				for (int k=0; k<=Nz; ++k) 
-				{	/*Create Left and right boundary faces*/
-					StateVecD xi(0.0,j*step,k*step);
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-					pID++;
-					xi(0) = svar.bound_box(0);
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-					pID++;
+			// for(int j = 0; j <= Ny ; ++j) 
+			// {
+			// 	for (int k=0; k<=Nz; ++k) 
+			// 	{	/*Create Left and right boundary faces*/
+			// 		StateVecD xi(0.0,j*step,k*step);
+			// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+			// 		pID++;
+			// 		xi(0) = svar.bound_box(0);
+			// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+			// 		pID++;
+			// 	}
+				
+			// }
+			// for(int i = 1; i<Nx ; ++i) 
+			// {
+			// 	for (int j=1; j<Ny; ++j)
+			// 	{	/*Create top and bottom boundary faces*/
+			// 		StateVecD xi(i*step,j*step,0);
+			// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+			// 		pID++;
+			// 		// xi(2)= bound_box(2); //Top boundary (Typically omitted)
+			// 		// pn.emplace_back(SPHPart(xi,v,f,rho,Rrho,bndM,0));
+			// 	}
+				
+			// }
+			// for(int i= 1; i<Nx; ++i) 
+			// {
+			// 	for(int k = 0; k <= Nz; ++k) 
+			// 	{	/*Create far and near boundary*/
+			// 		StateVecD xi(i*step, 0, k*step);
+			// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+			// 		pID++;
+			// 		xi(1) = svar.bound_box(1);
+			// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+			// 		pID++;
+			// 	}
+			// }
+
+			for(int level = nlevels-1; level >=0; level--)
+			{	
+				for(real z = svar.bound_start[2]+dz-svar.Pstep; z <= svar.bound_box[2]+svar.bound_start[2]; z+=dz )
+				{
+					for(real y = svar.bound_box[1] + svar.bound_start[1]; y >= svar.bound_start[1]-(nlevels)*dy-svar.Pstep; y -= dy)
+					{	/* Left wall */
+						StateVecD xi(svar.bound_start[0] - (level)*dx - svar.Pstep, y, z);
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+						pID++;
+					}
+
+					for(real x = svar.bound_start[0]- svar.Pstep + dx; x <=  svar.bound_box[0]+svar.bound_start[0]+svar.Pstep; x += dx) 
+					{	/*Floor*/
+						StateVecD xi(x, svar.bound_start[1] - (level)*dy - svar.Pstep, z);
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+						pID++;
+					}
+
+					for(real y =  svar.bound_start[1]-(nlevels)*dy-svar.Pstep; y <= svar.bound_box[1] + svar.bound_start[1]; y += dy)
+					{	/* Right wall */
+						StateVecD xi(svar.bound_start[0] + svar.bound_box[0] + (level)*dx + svar.Pstep, y, z);
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+						pID++;
+					}
+
+				}
+
+				for(real y =  svar.bound_start[1]-(nlevels)*dy-svar.Pstep; y <= svar.bound_box[1] + svar.bound_start[1]; y += dy)
+				{	
+					for(real x = svar.bound_start[0]- svar.Pstep + dx; x <=  svar.bound_box[0]+svar.bound_start[0]+svar.Pstep; x += dx) 
+					{	/* Back wall */
+						StateVecD xi(x, y, svar.bound_start[2] - (level)*dz - svar.Pstep );
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+						pID++;
+
+					}
+				}
+
+				for(real y =  svar.bound_start[1]-(nlevels)*dy-svar.Pstep; y <= svar.bound_box[1] + svar.bound_start[1]; y += dy)
+				{	
+					for(real x = svar.bound_start[0] - svar.Pstep + dx; x <=  svar.bound_box[0]+svar.bound_start[0]+svar.Pstep; x += dx) 
+					{	/* Front wall */
+						StateVecD xi(x, y, svar.bound_start[2] + svar.bound_box[2] + (level)*dz + svar.Pstep );
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+						pID++;
+					}
 				}
 				
-			}
-			for(int i = 1; i<Nx ; ++i) 
-			{
-				for (int j=1; j<Ny; ++j)
-				{	/*Create top and bottom boundary faces*/
-					StateVecD xi(i*step,j*step,0);
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-					pID++;
-					// xi(2)= bound_box(2); //Top boundary (Typically omitted)
-					// pn.emplace_back(SPHPart(xi,v,f,rho,Rrho,bndM,0));
-				}
 				
+				// 	// Optional lid
+				// for(int i = 1; i <Nx ; ++i) {
+				// 	StateVecD xi(i*stepx,bound_box(1));
+				// 	particles.emplace_back(SPHPart(xi,v,f,rho,Rrho,bndM,Bound));	
+				// }
+				// StateVecD x(stepx-svar.bound_start(0),(Ny+0.5)*stepy);
+				// pn.emplace_back(SPHPart(x,v,f,rho,fvar.bndM,true));
+				// x(0) = svar.bound_box(0) -stepx;
+				// pn.emplace_back(SPHPart(x,v,f,rho,fvar.bndM,true));
 			}
-			for(int i= 1; i<Nx; ++i) 
-			{
-				for(int k = 0; k <= Nz; ++k) 
-				{	/*Create far and near boundary*/
-					StateVecD xi(i*step, 0, k*step);
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-					pID++;
-					xi(1) = svar.bound_box(1);
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-					pID++;
-				}
-			}
+
 		#else /*SIMDIM == 2*/
-			for(int i = 0; i <= Ny ; ++i) 
-			{	/* Left Wall*/
-				StateVecD xi(-svar.bound_start(0)-2*svar.Pstep,i*step-svar.bound_start(1)-2*svar.Pstep);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-				pID++;
-			}
-	/*			// Optional lid
-			for(int i = 1; i <Nx ; ++i) {
-				StateVecD xi(i*stepx,bound_box(1));
-				particles.emplace_back(SPHPart(xi,v,f,rho,Rrho,bndM,Bound));	
-			}
-			StateVecD x(stepx-svar.bound_start(0),(Ny+0.5)*stepy);
-			pn.emplace_back(SPHPart(x,v,f,rho,fvar.bndM,true));
-			x(0) = svar.bound_box(0) -stepx;
-			pn.emplace_back(SPHPart(x,v,f,rho,fvar.bndM,true));
-	*/
-			for(int i= Ny; i>0; --i) 
-			{	/*Right Wall*/
-				StateVecD xi(Nx*step-svar.bound_start(0)-2*svar.Pstep,i*step-svar.bound_start(1)-2*svar.Pstep);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));	
-				pID++;
-			}
-			for(int i = Nx; i > 0; --i) 
-			{	/*Floor*/
-				StateVecD xi(i*step-svar.bound_start(0)-2*svar.Pstep,-svar.bound_start(1)-2*svar.Pstep);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
-				pID++;
+
+			for(int level = nlevels-1; level >=0; level--)
+			{
+				for(real y = svar.bound_box[1] + svar.bound_start[1]; 
+					y >= svar.bound_start[1]-(nlevels-1)*dy-svar.Pstep; y -= dy)
+				{	/* Left wall */
+					StateVecD xi(svar.bound_start[0] - (level)*dx - svar.Pstep, y);
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+					pID++;
+				}
+
+				for(real x = svar.bound_start[0]- svar.Pstep + dx; 
+					x <=  svar.bound_box[0]+svar.bound_start[0]+svar.Pstep; x += dx) 
+				{	/*Floor*/
+					StateVecD xi(x, svar.bound_start[1] - (level)*dy - svar.Pstep);
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+					pID++;
+				}
+
+				for(real y =  svar.bound_start[1]-(nlevels-1)*dy-svar.Pstep; 
+					y <= svar.bound_box[1] + svar.bound_start[1]; y += dy)
+				{	/* Right wall */
+					StateVecD xi(svar.bound_start[0] + svar.bound_box[0] + (level)*dx + svar.Pstep, y);
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
+					pID++;
+				}
+				
+				// 	// Optional lid
+				// for(int i = 1; i <Nx ; ++i) {
+				// 	StateVecD xi(i*stepx,bound_box(1));
+				// 	particles.emplace_back(SPHPart(xi,v,f,rho,Rrho,bndM,Bound));	
+				// }
+				// StateVecD x(stepx-svar.bound_start(0),(Ny+0.5)*stepy);
+				// pn.emplace_back(SPHPart(x,v,f,rho,fvar.bndM,true));
+				// x(0) = svar.bound_box(0) -stepx;
+				// pn.emplace_back(SPHPart(x,v,f,rho,fvar.bndM,true));
 			}
 		#endif		
 	}
@@ -159,7 +250,11 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 	{	/*Jet*/
 		int const interval = 20000;
 		#if SIMDIM == 3
-			real holeD = svar.jet_diam+6.75*svar.dx; /*Diameter of hole (or width)*/
+
+			real holeD = svar.jet_diam+2*svar.dx; /*Diameter of hole (or width)*/
+			if(svar.bound_solver == 1)
+				holeD += 3*svar.dx;
+
 			real stepb = (svar.Pstep*svar.Bstep);
 			
 			/*Create a bit of the pipe downward.*/
@@ -169,7 +264,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 	    	int ncirc = floor(2.0*M_PI/dtheta);
 	    	dtheta = 2.0*M_PI/real(ncirc);
 
-			for(real ii = 0; ii < 4; ii+=1.0)
+			for(real ii = 0; ii < 3; ii+=1.0)
 			{
 				r = 0.5*holeD + ii*stepb;
 				for (real y = 0; y >= -svar.jet_depth-stepb; y-=stepb)			
@@ -179,7 +274,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 						StateVecD perturb(random(interval), random(interval), random(interval));
 						StateVecD xi(r*sin(theta), y, r*cos(theta));
 						xi += perturb;
-						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 						pID++;
 					}	
 				}
@@ -187,27 +282,29 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		#else
 
 			real jetR = 0.5*(svar.jet_diam+2*svar.dx); /*Radius of hole (or width)*/
+			if(svar.bound_solver == 1)
+				jetR += 2*svar.dx;
+
 			real stepb = (svar.Pstep*svar.Bstep);
 			
 			/*Create a bit of the pipe downward.*/
-			for(real ii = 0; ii < 4; ii+=1.0)
+			for(real x = jetR; x < jetR + 2*fvar.H - svar.dx; x+=stepb)
 			{
-				real x = jetR + ii*stepb;
-				for (real y = 0.0; y >= -svar.jet_depth - 2.0 * stepb; y-=stepb)			
+				for (real y = 0.0; y >= -(svar.jet_depth + 4.0 * svar.dx); y-=stepb)			
 				{
 					StateVecD perturb(random(interval), random(interval));
 					StateVecD xi(-x,y);
 					xi += perturb;
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 					pID++;
 				}
 
-				for (real y = 0.0; y >= -svar.jet_depth - 2.0 * stepb; y -= stepb)
+				for (real y = 0.0; y >= -(svar.jet_depth + 4.0 * svar.dx); y -= stepb)
 				{
 					StateVecD perturb(random(interval), random(interval));
 					StateVecD xi(x,y);
 					xi += perturb;
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 					pID++;
 				}
 			}
@@ -228,7 +325,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 				for(real theta = 0; theta < 2*M_PI; theta += dtheta)
 				{
 					StateVecD xi(r*sin(theta), y, r*cos(theta));
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 					pID++;
 				}	
 			}
@@ -240,7 +337,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 				for(real theta = 0; theta < 2*M_PI; theta += dtheta)
 				{
 					StateVecD xi(x*sin(theta), y, x*cos(theta));
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 					pID++;
 				}	
 			}
@@ -253,7 +350,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 				for(real theta = 0; theta < 2*M_PI; theta += dtheta)
 				{
 					StateVecD xi(r*sin(theta), y, r*cos(theta));
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 					pID++;
 				}	
 			}
@@ -267,7 +364,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 			for (real y = -svar.jet_depth*2; y >= -svar.jet_depth*3; y-=stepb)
 			{
 				StateVecD xi(-resR,y);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 				pID++;
 			}	
 
@@ -277,7 +374,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 				/*Interpolate between resR and jetR*/
 				real x = resR + (y-2*svar.jet_depth)*(jetR-resR)/(-svar.jet_depth);
 				StateVecD xi(-x,y);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 				pID++;
 			}
 
@@ -285,7 +382,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 			for (real y = 0; y > -svar.jet_depth; y-=stepb)
 			{
 				StateVecD xi(-jetR,y);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 				pID++;
 			}
 
@@ -293,7 +390,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 			for (real y = -svar.jet_depth*2; y >= -svar.jet_depth*3; y-=stepb)
 			{
 				StateVecD xi(resR,y);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 				pID++;
 			}
 
@@ -303,7 +400,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 				/*Interpolate between resR and jetR*/
 				real x = resR + (y-2*svar.jet_depth)*(jetR-resR)/(-svar.jet_depth);
 				StateVecD xi(x,y);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 				pID++;
 			}
 
@@ -311,7 +408,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 			for (real y = 0; y > -svar.jet_depth; y-=stepb)
 			{
 				StateVecD xi(jetR,y);
-				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+				pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 				pID++;
 			}
 		#endif
@@ -334,7 +431,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	{ /*Do the centerline of points*/
 		// 		real y = -(2*svar.jet_depth+tankD+fvar.H);
 		// 		StateVecD xi(0.0,y,z);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,BOUND,pID));
 		// 		++pID;
 		// 	}
 
@@ -346,13 +443,13 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		//     		{   /*If the point is inside the hole diameter, add it*/
 		//     			real y = -(2*svar.jet_depth+tankD+fvar.H);
 		// 				StateVecD xi(x,y,z);
-		// 				pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,PartState.BOUND_,pID));
+		// 				pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,BOUND,pID));
 		// 				++pID;
 		// 				++svar.simPts;
 		// 				++svar.nrefresh;
 
 		// 				xi(0) = -x;
-		// 				pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,PartState.BOUND_,pID));
+		// 				pn.emplace_back(SPHPart(xi,v,rho,fvar.simM,press,BOUND,pID));
 		// 				++pID;
 		// 			}
 		// 		}
@@ -367,7 +464,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 		{
 		// 			StateVecD xi(resR*sin(theta), y, resR*cos(theta));
 		// 			/*Apply Rotation...*/
-		// 			pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 			pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 			pID++;
 		// 		}	
 		// 	}
@@ -381,7 +478,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 		{
 		// 			StateVecD xi(x*sin(theta), y, x*cos(theta));
 		// 			/*Apply Rotation...*/
-		// 			pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 			pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 			pID++;
 		// 		}	
 		// 	}
@@ -394,7 +491,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 		{
 		// 			StateVecD xi(jetR*sin(theta), y, jetR*cos(theta));
 		// 			/*Apply Rotation...*/
-		// 			pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 			pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 			pID++;
 		// 		}	
 		// 	}
@@ -414,7 +511,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	for(real x = -(resR-fvar.H); x < (resR -fvar.H); x+=stepb)
 		// 	{
 		// 		StateVecD xi(x,-(2*svar.jet_depth+tankD+3*fvar.H));
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 		svar.psnPts = pID;
 		// 	}
@@ -424,7 +521,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	for (real y = -(svar.jet_depth*2+tankD+3*fvar.H); y <= -svar.jet_depth*2; y+=stepb)
 		// 	{
 		// 		StateVecD xi(-resR,y);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 	}
 
@@ -436,7 +533,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 		/*Interpolate between resR and jetR*/
 		// 		real x = resR - (y+2*svar.jet_depth)*(jetR-resR)/(-svar.jet_depth);
 		// 		StateVecD xi(-x,y);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 	}
 
@@ -444,7 +541,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	for (real y = -svar.jet_depth; y < 0; y+=stepb)
 		// 	{
 		// 		StateVecD xi(-jetR,y);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 	}
 
@@ -452,7 +549,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	for (real y = 0; y > -svar.jet_depth; y-=stepb)
 		// 	{
 		// 		StateVecD xi(jetR,y);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 	}
 
@@ -462,7 +559,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 		/*Interpolate between resR and jetR*/
 		// 		real x = resR - (y+2*svar.jet_depth)*(jetR-resR)/(-svar.jet_depth);
 		// 		StateVecD xi(x,y);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 	}
 
@@ -470,7 +567,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	for (real y = -svar.jet_depth*2; y >= -(svar.jet_depth*2+tankD+3*fvar.H); y-=stepb)
 		// 	{
 		// 		StateVecD xi(resR,y);
-		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.BOUND_,pID));
+		// 		pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,BOUND,pID));
 		// 		pID++;
 		// 	}
 		// #endif
@@ -499,9 +596,9 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		for (y = 0.0; y >  -svar.jet_depth; y-= svar.dx)
 		{
 			#if SIMDIM == 3
-				Add_Radial_Points(y, svar, fvar, avar, pn, PartState.FREE_);
+				Add_Radial_Points(y, svar, fvar, avar, pn, FREE);
 			#else
-				AddPoints(y, svar, fvar, avar, pn, PartState.FREE_);
+				AddPoints(y, svar, fvar, avar, pn, FREE);
 			#endif
 		}
 	}
@@ -528,7 +625,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 			for (real y = -svar.jet_depth*2; y > -svar.jet_depth*3; y-=svar.dx)
 			{
 				// cout << "In add points for-loop" << endl;
-				AddPoints(y, svar, fvar, avar, pn, PartState.PIPE_);
+				AddPoints(y, svar, fvar, avar, pn, PIPE);
 			}
 
 			Add_Buffer(svar,fvar,pn);
@@ -539,9 +636,9 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 			for (y = 0.0; y >  -svar.jet_depth; y -= svar.dx)
 			{
 				#if SIMDIM == 3
-					Add_Radial_Points(y, svar, fvar, avar, pn, PartState.PIPE_);
+					Add_Radial_Points(y, svar, fvar, avar, pn, PIPE);
 				#else
-					AddPoints(y, svar, fvar, avar, pn, PartState.PIPE_);
+					AddPoints(y, svar, fvar, avar, pn, PIPE);
 				#endif
 			}
 
@@ -561,7 +658,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 					for (int k=0; k < svar.xyPART(2); ++k )
 					{
 						StateVecD xi(i*svar.dx,	j*svar.dx, k*svar.dx);		
-						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.FREE_,pID));
+						pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,FREE,pID));
 						pID++;
 					}		
 				}
@@ -573,7 +670,7 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 				for(int j=0; j< svar.xyPART(1); ++j)
 				{				
 					StateVecD xi(i*svar.dx,j*svar.dx);		
-					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,PartState.FREE_,pID));
+					pn.emplace_back(SPHPart(xi,v,rho,fvar.bndM,press,FREE,pID));
 					// pn.back().cellP = 20000-fvar.gasPress;
 					pID++;
 				}
@@ -582,14 +679,8 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 
 	}
 
-
-		
-	// svar.simPts+=10*10;
-
 	svar.totPts = pn.size();
 	svar.partID = pn.size();
-
-	
 
 	for(size_t ii = 0; ii < svar.bndPts; ++ii)
 		pn[ii].xi = (svar.Rotate * pn[ii].xi) + svar.bound_start;
@@ -602,6 +693,18 @@ void InitSPH(SIM& svar, FLUID const& fvar, AERO const& avar, SPHState& pn, SPHSt
 		// 	pn[ii].cellV = avar.vInf;
 		// }
 	}
+
+	if(svar.init_hydro_pressure)
+	{	/* If using hydrostatic initialisation, set pressure */
+		for(size_t ii = 0; ii < svar.totPts; ++ii)
+		{
+			real press = std::max(0.0, fvar.rho0 * svar.grav[1] * (svar.hydro_height -  pn[ii].xi[1]));
+			real dens = density_equation(press, fvar.B, fvar.gam, fvar.Cs, fvar.rho0);
+			pn[ii].p = press;
+			pn[ii].rho = dens;
+		}
+	}
+	
 	pnp1 = pn;
 
 	// cout << "Boundary pn: " << svar.bndPts << endl;

--- a/src/Kernel.h
+++ b/src/Kernel.h
@@ -5,7 +5,7 @@
 
 #ifdef CUBIC
 	///******Cubic Spline Kernel*******///
-	real const Kernel(real const dist, real const H, real const correc)
+	inline real const Kernel(real const dist, real const H, real const correc)
 	{
 		real const q = dist/H;
 
@@ -21,7 +21,7 @@
 		return 0;
 	}
 
-	StateVecD const GradK(StateVecD const& Rij, real const dist, real const H, real const correc)
+	inline StateVecD const GradK(StateVecD const& Rij, real const dist, real const H, real const correc)
 	{
 		real const q = dist/H;
 
@@ -39,7 +39,7 @@
 
 #else
 	///******Wendland's C2 Quintic Kernel*******///
-	real const Kernel(real const& dist, real const& H, real const& correc) 
+	inline real const Kernel(real const& dist, real const& H, real const& correc) 
 	{
 		// if(dist/H > 2.0)
 		// {
@@ -50,7 +50,7 @@
 	}
 
 	/*Gradient*/
-	StateVecD const GradK(StateVecD const& Rij, real const& dist, real const& H, real const& correc)
+	inline StateVecD const GradK(StateVecD const& Rij, real const& dist, real const& H, real const& correc)
 	{
 		if(dist/H < 1e-12)
 		{
@@ -67,7 +67,7 @@
 #endif
 
 
-real const BoundaryKernel(real const dist, real const H, real const beta)
+inline real const BoundaryKernel(real const dist, real const H, real const beta)
 {
 	real const q = dist/H;
 	if (q < 2.0/3.0)
@@ -85,4 +85,30 @@ real const BoundaryKernel(real const dist, real const H, real const beta)
 	return 0;
 }
 
+/* Consider making a member function of fvar. Then can use member variables and only have 1 input */
+inline real pressure_equation(real const& rho, real const& B, real const& gam, 
+							real const& Cs, real const& rho0)
+{
+	#ifdef COLEEOS
+		(void)Cs;
+		return B*(pow(rho/rho0,gam)-1); /* Cole EOS */
+	#else
+		(void)B;
+		(void)gam;
+		return Cs*Cs * (rho - rho0); /* Isothermal EOS */
+	#endif
+}
+
+inline real density_equation(real const& press, real const& B, real const& gam, 
+							real const& Cs, real const& rho0)
+{
+	#ifdef COLEEOS
+		(void)Cs;
+		return rho0*pow((press/B) + 1.0, 1.0/gam); /* Cole EOS */
+	#else
+		(void)B;
+		(void)gam;
+		return press/(Cs*Cs) + rho0; /* Isothermal EOS */
+	#endif
+}
 #endif

--- a/src/Resid.h
+++ b/src/Resid.h
@@ -15,155 +15,193 @@
 #include "Var.h"
 #include "Kernel.h"
 #include "Aero.h"
-#include "Add.h"
+// #include "Add.h"
 
-// /*Numerical particle density for Nair & Poeschel (2017) surface tension*/
-real GetNumpartdens(SIM const& svar, FLUID const& fvar, SPHState const& pnp1, OUTL const& outlist)
-{
-	real npd = 0.0;
-	uint const& end = svar.totPts;
-	#pragma omp parallel for reduction(+:npd)
-	for (size_t ii = 0; ii < end; ++ii)
-	{
-		// StateVecD const& pi = pnp1[ii].xi;
-		for (auto const& jj:outlist[ii])
-		{ /* Surface Tension calcs */
-			// StateVecD const& pj = pnp1[jj.first].xi;
-			real const r = sqrt(jj.second);
-			// real const r = (pj-pi).norm();
-			npd += Kernel(r,fvar.H,fvar.correc);
-		}
-	}
-	return npd/real(svar.totPts);
-}
+#if !defined(HESF) && !defined(CSF)
+#define PAIRWISE
+#endif
 
-// /*Surface Tension - Nair & Poeschel (2017)*/
-StateVecD SurfaceTens(FLUID const& fvar, SPHPart const& pj, StateVecD const& Rij, 
-					  real const& r, real const& npd)
-{
-	/*Surface tension factor*/
-	real const lam = (6.0/81.0*pow((2.0*fvar.H),3.0)/pow(M_PI,4.0)*
-							(9.0/4.0*pow(M_PI,3.0)-6.0*M_PI-4.0));
 
-	real fac=1.0; /*Boundary Correction Factor*/
-	if(pj.b==PartState.BOUND_) fac=(1+0.5*cos(M_PI*(fvar.contangb/180))); 
-
-	/*npd = numerical particle density (see code above) */
-	real const sij = 0.5*pow(npd,-2.0)*(fvar.sig/lam)*fac;
-	return -(Rij/r)*sij*cos((3.0*M_PI*r)/(4.0*fvar.H));
-}
-
+#ifdef HESF
 // /* Colour field gradient in He et al (2014) method, note the bottom variable to account for no air*/
 // std::vector<StateVecD> GetColourGrad(SIM const& svar, FLUID const& fvar, SPHState const& pnp1, OUTL const& outlist)
 // {
 // 	std::vector<StateVecD> cgrad(svar.totPts, StateVecD::Zero());
-// 	const uint& start = svar.bndPts;
-// 	const uint& end = svar.totPts;
+// 	uint const& start = svar.bndPts;
+// 	uint const& end = svar.totPts;
 
-// 	#pragma omp parallel for shared(outlist) reduction(+:cgrad)
+// 	#pragma omp parallel for  reduction(+:cgrad)
 // 	for(uint ii=start; ii < end; ++ii)
 // 	{
 // 		StateVecD const& pi = pnp1[ii].xi;
 // 		real bottom = 0.0;
 		
-// 		for(auto jj:outlist[ii])
+// 		for(auto const& jj:outlist[ii])
 // 		{	/*Find the denominator to correct absence of second phase*/
-// 			Part const& pj = pnp1[jj];
-// 			real const r = (pj.xi-pi).norm();
-// 			bottom +=(pj.m/pj.rho)*W2Kernel(r,fvar.H,fvar.correc);
+// 			SPHPart const& pj = pnp1[jj.first];
+// 			real const r = sqrt(jj.second);
+// 			bottom += (pj.m/pj.rho)*Kernel(r,fvar.H,fvar.correc);
 // 		}
 
-// 		for(auto jj:outlist[ii])
+// 		for(auto const& jj:outlist[ii])
 // 		{	/*Find the numerator and sum*/
-// 			Part const& pj = pnp1[jj];
-// 			StateVecD const Rij = pj.xi-pi;
-// 			real const r = Rij.norm();
-// 			cgrad[ii] += (pj.m/pj.rho)*W2GradK(Rij,r,fvar.H,fvar.correc);
+// 			SPHPart const& pj = pnp1[jj.first];
+// 			StateVecD const Rji = pj.xi-pi;
+// 			real const r = sqrt(jj.second);
+// 			cgrad[ii] += (pj.m/pj.rho)*GradK(Rji,r,fvar.H,fvar.correc);
 // 		}
 		
-// 		cgrad[ii] = cgrad[ii]/bottom;
+// 		cgrad[ii] /= bottom;
 // 	}
 
 // 	return cgrad;
 // }
 
-// /*Diffuse interface method from He et al (2014) for surface tension*/
-// StateVecD HeST(FLUID const& fvar, Part const& pi, Part const& pj, 
-// 			  StateVecD const& Rij, real const& r, StateVecD const& cgradi, StateVecD const& cgradj)
+/*Diffuse interface method from He et al (2014) for surface tension*/
+StateVecD HeST(StateVecD const& cgradi, StateVecD const& cgradj, StateVecD const& diffK)
+{
+	return 0.5*((cgradi.squaredNorm()+cgradj.squaredNorm()))*diffK;
+}
+
+#endif
+
+// /*Numerical particle density for Nair & Poeschel (2017) surface tension*/
+// real GetNumpartdens(SIM const& svar, FLUID const& fvar, SPHState const& pnp1, OUTL const& outlist)
 // {
-// 	return (0.01/2.0)*(pi.m/pi.rho)*(pj.m/pj.rho)*((cgradi.squaredNorm()+cgradj.squaredNorm())/2.0)
-// 		*W2GradK(Rij,r,fvar.H,fvar.correc);
+// 	real npd = 0.0;
+// 	uint const& end = svar.totPts;
+// 	#pragma omp parallel for reduction(+:npd)
+// 	for (size_t ii = 0; ii < end; ++ii)
+// 	{
+// 		// StateVecD const& pi = pnp1[ii].xi;
+// 		for (auto const& jj:outlist[ii])
+// 		{ /* Surface Tension calcs */
+// 			// StateVecD const& pj = pnp1[jj.first].xi;
+// 			real const r = sqrt(jj.second);
+// 			// real const r = (pj-pi).norm();
+// 			npd += Kernel(r,fvar.H,fvar.correc);
+// 		}
+// 	}
+// 	return npd/real(svar.totPts);
 // }
+
+// /*Surface Tension - Nair & Poeschel (2017)*/
+#ifdef PAIRWISE
+inline real surface_tension_fac(int const bA, int const bB)
+{
+	if(bA == BOUND || bB == BOUND )
+	{
+		real contang = 0.5 * M_PI * 7.0/9.0;
+		return (1.0 + 0.5*cos(contang));
+	}
+	return 1.0;
+}
+
+inline StateVecD SurfaceTens(StateVecD const& Rji, real const& r, real const& h, real const& sig,  real const& lam, 
+					real const& npdm2, real const& pi3o4, int const& bA, int const& bB)
+{
+	real fac = surface_tension_fac(bA, bB); 
+
+	/*npd = numerical particle density (see code above) */
+	return -0.5*npdm2*(sig/lam)*fac*cos(pi3o4*r/h)*(Rji/r);
+}
+#endif
+
+#ifdef CSF
+inline void CSF_Curvature(FLUID const& fvar, DELTAP const& dp, SPHPart const& pi, SPHPart const& pj,
+					StateVecD const& Rji, StateVecD const& gradK, real const& volj, real const& r, real& curve, real& correc)
+{
+	if( dp.lam[pj.partID] < 0.75 )
+	{	
+		curve -= (pj.norm.normalized()-pi.norm.normalized()).dot(volj*gradK);
+		correc += volj * Kernel(r,fvar.H,fvar.correc)/*/dp.kernsum[ii]*/;
+	}	
+
+	/* Consider imaginary particles to improve curvature representation */
+	if(pi.surf == 1 && pj.surf != 1)
+	{	
+		/* Host particle is on the surface, but neighbour is not. Reflect stuff then */
+		StateVecD normj = 2*pi.norm.normalized() - pj.norm.normalized();
+		curve += (normj.normalized()-pi.norm.normalized()).dot(volj*gradK);
+		correc += volj * Kernel(r,fvar.H,fvar.correc)/*/dp.kernsum[ii]*/;
+	}
+
+	if(pj.surf == 1 && pi.surf != 1)
+	{
+		/* Neighbour particle is on the surface, but host is not. Not as easy */
+		/* Need to check if extended particle is still in the neighbourhood */
+		if(r < fvar.H)
+		{	/* Assuming a support radius of 2h, if the current particle is within h */
+			/* it will still be in the neighbourhood if distance is doubled */
+			StateVecD gradK2 = GradK(2*Rji,2*r,fvar.H,fvar.correc);
+			StateVecD normj = 2*pj.norm.normalized() - pi.norm.normalized();
+			curve -= (normj.normalized()-pi.norm.normalized()).dot(volj*gradK2);
+			correc += volj * Kernel(r,fvar.H,fvar.correc)/*/dp.kernsum[ii]*/;
+		}
+	}
+}
+#endif
 
 #ifdef ALE
 /* Arbitrary Lagrangian Eulerian formulation - Sun, Colagrossi, Marrone, Zhang (2018)*/
-StateVecD ALEMomentum(SPHPart const& pi, SPHPart const& pj, real const& Vj, StateVecD const& gradK, real const& rho0)
+inline StateVecD ALEMomentum(SPHPart const& pi, SPHPart const& pj, real const& Vj, StateVecD const& gradK, real const& rho0)
 {
-	return 	(rho0/pi.rho) * (pj.v * pj.vPert.transpose() + pi.v * pi.vPert.transpose()) * gradK * Vj 
-			- pi.v * (pj.vPert - pi.vPert).dot(gradK) * Vj ;
+	return 	 ((pj.v * pj.vPert.transpose() + pi.v * pi.vPert.transpose()) * gradK 
+			- pi.v * (pj.vPert - pi.vPert).dot(gradK)) * Vj ;
 }
 
-real ALEContinuity(SPHPart const& pi, SPHPart const& pj, real const& Vj, StateVecD const& gradK)
+inline real ALEContinuity(SPHPart const& pi, SPHPart const& pj, real const& Vj, StateVecD const& gradK)
 {
-	return pi.rho*((pj.v+pj.vPert) - (pi.v + pi.vPert)).dot(gradK)*Vj/*  - 
-			(pj.rho*pj.vPert + pi.rho*pi.vPert).dot(gradK)*Vj */ ;
+	return ((pj.v+pj.vPert) - (pi.v + pi.vPert)).dot(gradK)*Vj;
+}
+
+inline real ALECont2ndterm(SPHPart const& pi, SPHPart const& pj, real const& Vj, StateVecD const& gradK)
+{
+	return (pj.rho*pj.vPert + pi.rho*pi.vPert).dot(gradK)*Vj;
 }
 #endif
 
 /* delta-SPH dissipation term in the continuity equation*/
-#ifdef DSPH
-real Continuity_dSPH(StateVecD const& Rij, real const& rr, real const& HSQ, StateVecD const& Grad, 
+#ifndef NODSPH
+inline real Continuity_dSPH(StateVecD const& Rji, real const& idist2, real const& HSQ, StateVecD const& Grad, 
 				real const& volj, StateVecD const& gRho_i, StateVecD const& gRho_j, SPHPart const& pi, SPHPart const& pj)
 {
-	real const psi_ij = ((pj.rho - pi.rho) + 0.5*(gRho_i + gRho_j).dot(Rij));
-	return volj * psi_ij * Rij.dot(Grad)/(rr+0.001*HSQ);
+	return volj * ((pj.rho - pi.rho) - 0.5*(gRho_i + gRho_j).dot(Rji)) * Rji.dot(Grad)*idist2;
 }
 #endif
 
 
-// StateVecD ArtVisc(StateVecD const& Rij, StateVecD const& Vij, real const r, 
-// 	 StateVecD const& gradK, real const& Vj)
-// {
-//     return Vij.dot(Rij) * Vj * gradK / (r*r);
-// }
-
-
-// StateVecD BasePos(real const& Pi, real const& Pj, real const& Vj, StateVecD const& gradK)
-// {
-// 	/* Positive Pressure - Sun, Colagrossi, Marrone, Zhang (2016)*/
-// 	return gradK * Vj * (Pj + Pi);
-// }
-
-// StateVecD BaseNeg(real const& Pi, real const& Pj, real const& Vj, StateVecD const& gradK)
-// {
-// 	/* Negative Pressure - Sun, Colagrossi, Marrone, Zhang (2016)*/
-// 	return gradK * Vj * (Pj - Pi);
-// }
-
-// StateVecD ArtVisc(StateVecD const& Rij, StateVecD const& Vij, real const r, 
-// 	 StateVecD const& gradK, real const& Vj)
-// {
-//     return Vij.dot(Rij) * Vj * gradK / (r*r);
-// }
-
-StateVecD BasePos(SPHPart const& pi, SPHPart const& pj, StateVecD const& gradK)
+inline StateVecD BasePos(SPHPart const& pi, SPHPart const& pj, StateVecD const& gradK)
 {
 	/* Positive Pressure - Monaghan (1994)*/
-	return gradK * (pj.p*pow(pj.rho,-2)+pi.p*pow(pi.rho,-2));
+	return pj.m * gradK * (pj.p/(pj.rho*pj.rho)+pi.p/(pi.rho*pi.rho));
 }
 
-StateVecD BaseNeg(SPHPart const& pi, SPHPart const& pj, StateVecD const& gradK)
+inline StateVecD BaseNeg(SPHPart const& pi, SPHPart const& pj, StateVecD const& gradK)
 {
 	/* Negative Pressure - Monaghan (1994)*/
-	return gradK * (pj.p*pow(pj.rho,-2)-pi.p*pow(pi.rho,-2));
+	return pj.m * gradK * (pj.p/(pj.rho*pj.rho)-pi.p/(pi.rho*pi.rho));
 }
 
-StateVecD ArtVisc(real const& nu, SPHPart const& pi, SPHPart const& pj, FLUID const& fvar, StateVecD const& Rij, StateVecD const& Vij, real const rr, 
-	 StateVecD const& gradK)
+inline StateVecD pressPos(real const& volj, SPHPart const& pi, SPHPart const& pj, StateVecD const& gradK)
 {
-	if(pj.b != PartState.BOUND_)
-	{
-		real const vdotr = Vij.dot(Rij);
+	/* Positive Pressure - Marrone et al. (2011)*/
+	return gradK * (pj.p + pi.p) * volj;
+}
+
+inline StateVecD pressNeg(real const& volj, SPHPart const& pi, SPHPart const& pj, StateVecD const& gradK)
+{
+	/* Negative Pressure - Marrone et al. (2011)*/
+	return gradK * (pj.p - pi.p) * volj;
+}
+
+// #ifdef COLEEOS
+inline StateVecD ArtVisc(real const& nu, SPHPart const& pi, SPHPart const& pj, FLUID const& fvar, 
+				StateVecD const& Rji, StateVecD const& Vji, real const idist2, StateVecD const& gradK)
+{
+	// if(pj.b != BOUND)
+	// {
+		real const vdotr = Vji.dot(Rji);
 
 		if (vdotr > 0.0) 
 		{
@@ -171,7 +209,7 @@ StateVecD ArtVisc(real const& nu, SPHPart const& pi, SPHPart const& pj, FLUID co
 		}
 		else
 		{	
-			real const muij= fvar.H*vdotr/(rr+0.0001*fvar.HSQ);
+			real const muij= fvar.H*vdotr*idist2;
 			real const rhoij = 0.5*(pi.rho+pj.rho);
 			real const cbar = 0.5*(sqrt((fvar.B*fvar.gam)/pi.rho)+sqrt((fvar.B*fvar.gam)/pj.rho));
 
@@ -180,29 +218,45 @@ StateVecD ArtVisc(real const& nu, SPHPart const& pi, SPHPart const& pj, FLUID co
 
 			return gradK * alpha *cbar*muij/rhoij;
 		}
-	}
-	else
-		return StateVecD::Zero();
+	// }
+
+	return StateVecD::Zero();
 }
+// #else
+inline StateVecD aVisc(StateVecD const& Rji, StateVecD const& Vji, real const idist2, 
+	 StateVecD const& gradK, real const& volj)
+{
+	real const vdotr = Vji.dot(Rji);
+
+	if (vdotr > 0.0) 
+	{
+		return StateVecD::Zero();
+	}
+	
+    return vdotr * volj * gradK * idist2;
+}
+// #endif
+
+
 
 /*Laminar Viscosity - Morris (2003)*/
 /*Apparently divergent at free surfaces - consider removing.*/
 // StateVecD Viscosity(real const& mu, real const& HSQ, SPHPart const& pi, SPHPart const& pj, 
-// 	StateVecD const& Rij, StateVecD const& Vij, real const& r, StateVecD const& gradK)
+// 	StateVecD const& Rji, StateVecD const& Vji, real const& r, StateVecD const& gradK)
 // {
-// 	return Vij*(mu/(pi.rho*pj.rho))*(1.0/(r*r+0.01*HSQ))*Rij.dot(gradK);
+// 	return Vji*(mu/(pi.rho*pj.rho))*(1.0/(r*r+0.01*HSQ))*Rji.dot(gradK);
 // }
 
-StateVecD Viscosity(real const& nu, real const& HSQ, SPHPart const& pi, SPHPart const& pj, 
-	StateVecD const& Rij, StateVecD const& Vij, real const& rr, StateVecD const& gradK)
+inline StateVecD Viscosity(real const& nu, SPHPart const& pi, SPHPart const& pj, 
+	StateVecD const& Rji, StateVecD const& Vji, real const& idist2, StateVecD const& gradK)
 
 {
-	return nu * (pi.rho + pj.rho)/(pi.rho*pj.rho) * (Rij.dot(gradK))/(rr + 0.001*HSQ) * Vij;		
+	return nu * (pi.rho + pj.rho)/(pi.rho*pj.rho) * (Rji.dot(gradK))*idist2 * Vji;		
 }
 
 
 /*Repulsion for interacting with mesh surface - saves generating particles on surface*/
-StateVecD NormalBoundaryRepulsion(FLUID const& fvar, MESH const& cells, SPHPart const& pi)
+inline StateVecD NormalBoundaryRepulsion(FLUID const& fvar, MESH const& cells, SPHPart const& pi)
 {
     real beta = 4*fvar.Cs*fvar.Cs;
     real kern = BoundaryKernel(pi.y,fvar.H,beta);
@@ -220,14 +274,15 @@ void Get_Boundary_Pressure(FLUID const& fvar, size_t const& end, OUTL const& out
 		StateVecD const g(0.0,-9.81);
 		// StateVecD const g(0.0,0.0);
 	#endif
-	#pragma omp parallel for schedule(static) shared(pnp1)/*Reduction defs in Var.h*/
+
+	#pragma omp parallel for schedule(static) default(shared)/*Reduction defs in Var.h*/
 	for (size_t ii=0; ii < end; ++ii)
 	{
 		SPHPart const& pi = pnp1[ii];
 
 		real kernsum = 0.0;
 		real pkern = 0.0;
-		real acckern = 0.0;
+		StateVecD acckern = StateVecD::Zero();
 		// StateVecD velkern = StateVecD::Zero();
 
 		/* Get the 'extrapolated velocity' of the boundary  */
@@ -235,7 +290,7 @@ void Get_Boundary_Pressure(FLUID const& fvar, size_t const& end, OUTL const& out
 		// {	/* Neighbour list loop. */
 		// 	SPHPart const& pj = pnp1[jj.first];
 		// 	/*Check if the neighbour is a fluid particle*/
-		// 	if(pj.b > PartState.PISTON_)
+		// 	if(pj.b > PISTON)
 		// 	{
 		// 		real const rr = jj.second;
 		// 		real const r = sqrt(rr);
@@ -252,19 +307,19 @@ void Get_Boundary_Pressure(FLUID const& fvar, size_t const& end, OUTL const& out
 			SPHPart const& pj = pnp1[jj.first];
 
 			/*Check if the neighbour is a fluid particle*/
-			if(pj.b > PartState.PISTON_)
+			if(pj.b > PISTON)
 			{
-				StateVecD const Rij = pj.xi-pi.xi;
+				StateVecD const Rji = pj.xi-pi.xi;
 				
 				real const rr = jj.second;
 				real const r = sqrt(rr);
 				real kern = Kernel(r,fvar.H,fvar.correc);
-				// StateVecD const Vij = pj.v-ext_vel;
-				// StateVecD const gradK = GradK(Rij,r,fvar.H,fvar.correc);/* gradK;*/
-				// StateVecD const aVisc = ArtVisc(fvar.nu,pi,pj,fvar,Rij,Vij,rr,gradK);
+				// StateVecD const Vji = pj.v-ext_vel;
+				// StateVecD const gradK = GradK(Rji,r,fvar.H,fvar.correc);/* gradK;*/
+				// StateVecD const aVisc = ArtVisc(fvar.nu,pi,pj,fvar,Rji,Vji,rr,gradK);
 				kernsum += kern;
 				pkern += pj.p * kern;
-				acckern +=  kern * (pj.rho * g /* + aVisc */).dot(Rij);
+				acckern +=  kern * pj.rho * Rji;
 			}
 		}/*End of neighbours*/
 
@@ -272,8 +327,8 @@ void Get_Boundary_Pressure(FLUID const& fvar, size_t const& end, OUTL const& out
 		real density = fvar.rho0;
 		if(kernsum > 0.0)
 		{
-			pressure = (pkern-acckern)/kernsum;
-			density = fvar.rho0*pow((pressure/fvar.B) + 1.0, 1.0/fvar.gam);
+			pressure = (pkern-g.dot(acckern))/kernsum;
+			density = density_equation(pressure,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 		}
 
 		pnp1[ii].p = pressure;
@@ -291,112 +346,81 @@ void Forces(SIM& svar, FLUID const& fvar, AERO const& avar, MESH const& cells, S
 	const size_t start = svar.bndPts;
 	const size_t end = svar.totPts;
 
-	// #pragma omp critical
-	// cout << endl << endl;
+	#ifdef PAIRWISE
+	real const npdm2 = 1/(dp.npd*dp.npd);
+	real const pi3o4 = 3.0*M_PI/4.0;
 
+	/*Surface tension factor*/
+	// #if SIMDIM==2
+	// real const lam = 8.0/81.0*pow(fvar.H,4)/pow(M_PI,4)*(9.0/4.0*pow(M_PI,3)-6.0*M_PI-4.0);
+	real const lam = (6.0/81.0*pow((2.0*fvar.H),3.0)/pow(M_PI,4.0)*
+							(9.0/4.0*pow(M_PI,3.0)-6.0*M_PI-4.0));
+	// #else
+	// real const lam = 3.0 / (4.0 * pow(M_PI, 4.0)) * (pow(2.0, 7) - 9.0 * pow(2.0, 4) 
+	// 				* M_PI * M_PI + 9.0 * 3.0 * pow(M_PI, 4)) * pow(fvar.H / 3.0, 5);
+	// #endif
 	
-	// const uint piston = svar.psnPts;
+	#endif
 
 	/********* LOOP 0 - all points: Calculate numpartdens ************/
 	// wDiff = GetWeightedDistance(svar,fvar,pnp1,outlist);
-	real const npd = GetNumpartdens(svar, fvar, pnp1, outlist);
+	// #ifdef HESF
 	// std::vector<StateVecD> const cgrad = GetColourGrad(svar,fvar,pnp1,outlist);
+	// #else
+	// #ifndef CSF
+	// #ifndef HESF
+	// real const npd = GetNumpartdens(svar, fvar, pnp1, outlist);
+	// #endif
+	// #endif
+	// 
 	// std::vector<StateVecD> ST(svar.totPts,StateVecD::Zero()); /*Surface tension force*/		
 
 	Rrho = vector<real>(end,0.0);
 	RV = vector<StateVecD>(end,StateVecD::Zero());
 	Af = vector<StateVecD>(end,StateVecD::Zero());
 
-	#pragma omp parallel shared(RV,Rrho,Af)
+	#pragma omp parallel default(shared)
 	{
 		/*Gravity Vector*/
 		StateVecD const& g = svar.grav;
 		
 
-/******** LOOP 2 - Boundary points: Calculate density and pressure. **********/		
-		// #pragma omp for schedule(static) nowait /*Reduction defs in Var.h*/
-		// for (size_t ii=0; ii < start; ++ii)
-		// {
-		// 	SPHPart const& pi = pnp1[ii];
-		// 	// pnp1[ii].theta = real(size);
-		// 	// pnp1[ii].theta = wDiff[ii];
-		// 	real Rrhoi = 0.0;
-		// 	real Rrhod = 0.0;
+		if(svar.bound_solver == 1)
+		{
+			/******** LOOP 2 - Boundary points: Calculate density and pressure. **********/		
+			#pragma omp for schedule(static) nowait /*Reduction defs in Var.h*/
+			for (size_t ii=0; ii < start; ++ii)
+			{
+				SPHPart const& pi = pnp1[ii];
+				// pnp1[ii].theta = real(size);
+				// pnp1[ii].theta = wDiff[ii];
+				real Rrhoi = 0.0;
 
-		// 	real kernsum = 0.0;
-		// 	real pkern = 0.0;
-		// 	real acckern = 0.0;
+				for (std::pair<size_t,real> const& jj : outlist[ii])
+				{	/* Neighbour list loop. */
+					SPHPart const& pj = pnp1[jj.first];
+					if(ii == jj.first)
+						continue;
 
-		// 	for (std::pair<size_t,real> const& jj : outlist[ii])
-		// 	{	/* Neighbour list loop. */
-		// 		SPHPart const& pj = pnp1[jj.first];
+					StateVecD const Rji = pj.xi-pi.xi;
+					StateVecD const Vji = pj.v-pi.v;
+					real const rr = jj.second;
+					real const r = sqrt(rr);
+					real const volj = pj.m/pj.rho;
+					StateVecD const gradK = /*dp.L[ii] * */GradK(Rji, r,fvar.H, fvar.correc);
 
-		// 		/*Check if the position is the same, and skip the particle if yes*/
-		// 		if(pj.b > PartState.PISTON_)
-		// 		{
-		// 			StateVecD const Rij = pj.xi-pi.xi;
-		// 			StateVecD const Vij = pj.v-pi.v;
-		// 			real const rr = jj.second;
-		// 			real const r = sqrt(rr);
-		// 			real const volj = pj.m/pj.rho;
-		// 			real kern = Kernel(r,fvar.H,fvar.correc);
-		// 			kernsum += kern;
-		// 			pkern += pj.p * kern;
-		// 			acckern += pj.rho * kern * (g  - pj.f).dot(Rij);
-		// 		}
-
-		// 		// StateVecD const Rij = pj.xi-pi.xi;
-		// 		// StateVecD const Vij = pj.v-pi.v;
-		// 		// real const rr = jj.second;
-		// 		// real const r = sqrt(rr);
-		// 		// real const volj = pj.m/pj.rho;
-		// 		// StateVecD const gradK = /*dp.L[ii] * */GradK(Rij, r,fvar.H, fvar.correc);
-
-		// 		// // StateVecD contrib = BasePos(pi.p,pj.p,volj,gradK);
-		// 		// // StateVecD contrib = BasePos(pi,pj,gradK);
-
-		// 		// /*drho/dt*/
-		// 		// Rrhoi -= pj.m*(Vij.dot(gradK));
-		// 		// Rrhod -= Continuity_dSPH(Rij,rr,fvar.HSQ,gradK,volj,dp.gradRho[ii],dp.gradRho[pj.partID],pi,pj);
-		// 		// RV[ii] -= pj.m*contrib;
-		// 	}/*End of neighbours*/
-			
-			 
-
-		// 	RV[ii] = StateVecD::Zero();
-		// 	Af[ii] = StateVecD::Zero();
-		// 	Rrho[ii] = (Rrhoi - fvar.dCont * Rrhod);
-
-		// } /*End of boundary parts*/
-
-		// vector<StateVecD> gradRho(end,StateVecD::Zero());
-
-		// #pragma omp for schedule(static) nowait
-		// for (size_t ii = start; ii < end; ++ii)
-		// {
-		// 	SPHPart const& pi = pnp1[ii];
-
-		// 	StateVecD gradRho_ = StateVecD::Zero();
-
-		// 	for(std::pair<size_t,real> const& jj:outlist[ii])
-		// 	{
-		// 		SPHPart const& pj = pnp1[jj.first];
-		// 		/*Check if the position is the same, and skip the particle if yes*/
-		// 		if(ii == jj.first)
-		// 			continue;
+					/*Base WCSPH continuity drho/dt*/
+					
+						Rrhoi -= volj*Vji.dot(gradK);
+					
+				}/*End of neighbours*/
+				
+				/* No dissipation terms for the boundary */
+				Rrho[ii] = Rrhoi*pi.rho;
 				
 
-		// 		StateVecD const Rij = pj.xi - pi.xi;
-		// 		real const r = sqrt(jj.second);
-		// 		real const volj = pj.m/pj.rho;
-		// 		StateVecD const Grad = GradK(-Rij,r,fvar.H,fvar.correc);
-
-		// 		gradRho_ += volj * (pj.rho - pi.rho)*Grad;          
-		// 	}
-
-		// 	gradRho[ii] = dp.L[ii]*gradRho_;
-		// }
-
+			} /*End of boundary parts*/
+		}
 
 /******* LOOP 4 - All simulation points: Calculate forces on the fluid. *********/
 		#pragma omp for reduction(+:Force,RV,Af) schedule(static) nowait
@@ -407,49 +431,46 @@ void Forces(SIM& svar, FLUID const& fvar, AERO const& avar, MESH const& cells, S
 			// pnp1[ii].theta = real(size);
 			// pnp1[ii].theta = wDiff[ii];
 
-			
 			real Rrhoi = 0.0;
-			#ifdef DSPH
-			real Rrhod = 0.0;			
+			#ifdef ALE
+			StateVecD RVia = StateVecD::Zero();
+			real Rrhoc = 0.0;
 			#endif
-			// real curve = 0.0;
-			// real correc = 0.0;
-
+			
+			#ifdef CSF
+			real curve = 0.0;
+			real correc = 0.0;
+			#endif
+			
 			StateVecD Vdiff = StateVecD::Zero();
 			real Pbasei = 0.0;
 
 			StateVecD aero = StateVecD::Zero();
 			StateVecD RVi = StateVecD::Zero();
-			StateVecD artViscI = StateVecD::Zero();
+			
 			StateVecD viscI = StateVecD::Zero();
 			StateVecD surfT = StateVecD::Zero();
+			
+			#ifdef NOFROZEN
+			StateVecD artViscI = StateVecD::Zero();
+			#ifndef NODSPH
+			real Rrhod = 0.0;			
+			#endif
+			#endif
 
-			if( dp.lam_ng[ii] < 0.75 /* pi.surf == 1 */ && pi.b == PartState.FREE_)
+			if( dp.lam_ng[ii] < avar.cutoff /* pi.surf == 1 */ && pi.b == FREE )
 			{
-				if (svar.Asource == 1)
-				{
-					Vdiff = (pi.cellV) - pi.v /* dp.avgV[ii] */;
-					// Pbasei = pi.cellP - avar.pRef;
-				}
-				else if (svar.Asource == 2)
+				Vdiff = pi.cellV - pi.v /* dp.avgV[ii] */;
+				
+				if (svar.Asource == 2)
 				{
 					Vdiff = (pi.cellV+cells.cPertnp1[pi.cellID]) - pi.v /* dp.avgV[ii] */;
 				}
-				else 
-				{
-					Vdiff = avar.vInf - pi.v /* dp.avgV[ii] */;
-				}
-
-				#if SIMDIM == 3
-					if(svar.Asource == 3)
-					{	
-						StateVecD const Vel = svar.vortex.getVelocity(pi.xi);
-						Vdiff = Vel - pi.v /* dp.avgV[ii] */;
-					}
-				#endif
-				// cout << ii << endl;
-				aero = CalcAeroForce(avar,pi,Vdiff,dp.norm[ii],dp.lam_ng[ii],Pbasei);
 				
+				aero = CalcAeroAcc(avar,pi,Vdiff,dp.norm[ii],dp.lam_ng[ii],Pbasei);
+				RV[ii] += aero;
+				Af[ii] += aero;
+				Force += aero;
 			}
 
 			for (std::pair<size_t,real> const& jj : outlist[ii])
@@ -458,119 +479,161 @@ void Forces(SIM& svar, FLUID const& fvar, AERO const& avar, MESH const& cells, S
 				/*Check if the position is the same, and skip the particle if yes*/
 				if(ii == jj.first)
 				{
-					if(/* pi.surf == 1 */ dp.lam_ng[ii] < 0.75 && pi.b == PartState.FREE_)
-					{
-						RV[ii] += aero / pi.m * fvar.correc/dp.kernsum[ii];
-						Af[ii] += aero / pi.m * fvar.correc/dp.kernsum[ii];
-						Force += aero / pi.m * fvar.correc/dp.kernsum[ii];
-					}	
+					// if(/* pi.surf == 1 */ dp.lam_ng[ii] < 0.75 && pi.b == FREE)
+					// {
+					// 	RV[ii] += aero * fvar.correc/dp.kernsum[ii];
+					// 	Af[ii] += aero * fvar.correc/dp.kernsum[ii];
+					// 	Force +=  aero * fvar.correc/dp.kernsum[ii];
+					// }	
 					continue;
 				}
 
-				StateVecD const Rij = pj.xi-pi.xi;
-				StateVecD const Vij = pj.v-pi.v;
+				StateVecD const Rji = pj.xi-pi.xi;
+				StateVecD const Vji = pj.v-pi.v;
 				real const rr = jj.second;
 				real const r = sqrt(rr);
-				#ifdef DSPH	
-				real const volj = pj.m/pj.rho;
-				#endif
-				// StateVecD const gradK = GradK(Rij,r,fvar.H,fvar.correc);
-				StateVecD const gradK = GradK(Rij,r,fvar.H,fvar.correc);/* gradK;*/
-
-				// if(gradK == StateVecD::Zero())
-				// {
-				// 	cout << ii << "  " << jj.first << endl;
-				// 	cout << rr << "  " << r << "  " << r/fvar.H << endl;
- 				// }
-
-				// if( /* dp.lam[ii] < 0.75 */ pi.surf == 1 )
-				// {
-				// 	// if(/* svar.iter % 10 == 0  &&*/ r > 1e-6*fvar.H)
-				// 	// 	gradLK = dp.L[ii]*gradK;
-
-				// 	if( /* dp.lam[pj.partID] < 0.75 */ pj.surf == 1 )
-				// 	{	
-				// 		curve -= (dp.norm[jj.first].normalized()-dp.norm[ii].normalized()).dot(volj*gradK);
-				// 		correc += volj * Kernel(r,fvar.H,fvar.correc)/*/dp.kernsum[ii]*/;
-				// 	}	
-				// }
+				real const idist2 = 1.0/(rr + 0.001*fvar.HSQ);
 				
-				if( dp.lam_ng[ii] < 0.75 /* pi.surf == 1 */ && pi.b == PartState.FREE_ && 
-					pj.b > PartState.PISTON_ && pj.b != PartState.GHOST_)
-				{	/* Assumed that particle masses are the same */
-					RV[jj.first] += aero / pi.m * Kernel(r,fvar.H,fvar.correc)/dp.kernsum[ii];
-					Af[jj.first] += aero / pi.m * Kernel(r,fvar.H,fvar.correc)/dp.kernsum[ii];
-					Force += aero / pi.m * Kernel(r,fvar.H,fvar.correc)/dp.kernsum[ii];
-				}	
+				// #if defined(CSF) || defined(HESF) || (!defined(NODSPH) && defined(NOFROZEN))
+					real const volj = pj.m/pj.rho;
+				// #endif
 
-				StateVecD const	contrib = BasePos(pi,pj,gradK);
+				// StateVecD const gradK = GradK(Rji,r,fvar.H,fvar.correc);
+				StateVecD const gradK = GradK(Rji,r,fvar.H,fvar.correc);/* gradK;*/	
+				
+				// if( dp.lam_ng[ii] < 0.75 && pi.b == FREE && 
+				// 	pj.b > PISTON && pj.b != GHOST)
+				// {	/* Assumed that particle masses are the same */
+				// 	RV[jj.first] += aero * Kernel(r,fvar.H,fvar.correc)/dp.kernsum[ii];
+				// 	Af[jj.first] += aero * Kernel(r,fvar.H,fvar.correc)/dp.kernsum[ii];
+				// 	Force += aero * Kernel(r,fvar.H,fvar.correc)/dp.kernsum[ii];
+				// }	
+
+				// StateVecD const	contrib = BasePos(pi,pj,gradK);
+				StateVecD const contrib = pressPos(volj,pi,pj,gradK);
 
 				#ifdef ALE
 					StateVecD const ALEcontrib = ALEMomentum(pi, pj, volj, gradK, fvar.rho0);
 				#endif
 
-				StateVecD const aVisc = ArtVisc(fvar.nu,pi,pj,fvar,Rij,Vij,rr,gradK);
-
 				/*Laminar Viscosity - Morris (2003)*/
-				StateVecD const visc = Viscosity(fvar.nu,fvar.HSQ,pi,pj,Rij,Vij,r,gradK);
+				StateVecD const visc = Viscosity(fvar.nu,pi,pj,Rji,Vji,idist2,gradK);
+				viscI += pj.m*visc;
+
+				/* Surface tension options */
+				if(/* pi.b == FREE  && */ pj.b != GHOST)
+				{
+					/* He et al (2014) - Diffuse Interface model */
+					#ifdef HESF
+					if( dp.lam[ii] < 0.75 /* pi.surf == 1 */ )
+					{
+						surfT += HeST(pi.norm/* /dp.colour[ii] */,pj.norm/* /dp.colour[jj.first] */,volj*gradK);
+					}
+					#endif
+
+					#ifdef CSF
+					/* Ordoubadi et al. (2017) - Continuum Surface Force + reflected particles */
+					if( dp.lam[ii] < 0.75 /* pi.surf == 1 */ )
+					{
+						CSF_Curvature(fvar,dp,pi,pj,Rji,gradK,volj,r,curve,correc);
+					}
+					#endif
+					
+					#ifdef PAIRWISE
+					#ifdef ALE
+					if(pi.surfzone == 1)	/* Nair & Poeschel (2017) - Pairwise force */
+					#endif
+						surfT += SurfaceTens(Rji,r, fvar.H, fvar.sig,lam,npdm2,pi3o4,pi.b,pj.b);
+					#endif	
+				}
+				
+				
+				#ifdef ALE
+					RVi -= contrib;
+					RVia += ALEcontrib;
+				#else
+					RVi -= contrib;
+				#endif
 
 				/*Base WCSPH continuity drho/dt*/
 				#ifdef ALE
 					Rrhoi -= ALEContinuity(pi,pj,volj,gradK);
+					Rrhoc += ALECont2ndterm(pi,pj,volj,gradK);
 				#else
-					Rrhoi -= pj.m*(Vij.dot(gradK));
+					// Rrhoi -= pj.m*(Vji.dot(gradK));
+					Rrhoi -= volj*Vji.dot(gradK);
 				#endif
 
-				#ifdef DSPH
-				Rrhod -= Continuity_dSPH(Rij,rr,fvar.HSQ,gradK,volj,dp.gradRho[ii],dp.gradRho[jj.first],pi,pj);
-				#endif
+				#ifdef NOFROZEN
+					if(pj.b != BOUND)
+					{
+						#ifndef NODSPH
+							Rrhod += Continuity_dSPH(Rji,idist2,fvar.HSQ,gradK,volj,
+												dp.gradRho[ii],dp.gradRho[jj.first],pi,pj);
+						#endif
 
-				/*Surface Tension - Nair & Poeschel (2017)*/
-				if(pi.b != PartState.GHOST_ && pj.b != PartState.GHOST_)
-					surfT += SurfaceTens(fvar,pj,Rij,r,npd);
+						artViscI += pj.m*ArtVisc(fvar.nu,pi,pj,fvar,Rji,Vji,idist2,gradK);
+					}
+				#endif
 				
-				// SurfC = HeST(fvar,pi,pj,Rij,r,cgrad[ii],cgrad[pj.partID]);	
 				
-				#ifdef ALE
-					RVi -= pj.m*contrib  - ALEcontrib;
-				#else
-					RVi -= pj.m*contrib;
-				#endif
-
-				artViscI += pj.m*aVisc;
-				viscI += pj.m*visc;
 
 			}/*End of neighbours*/
-			
-			// if(ii - start < 36)
-			// {
-			// #pragma omp critical
-			// cout << ii - start << "  " << RVi(0) << "   " << RVi(1) << "  " << artViscI(0) << "   " << artViscI(1) << "  " << viscI(0) << "   " << viscI(1) << endl; 
-			// }
 
 			if(pi.internal == 1)
 			{	// Apply the normal boundary force
 				RVi += NormalBoundaryRepulsion(fvar, cells, pi);
 			}
 
-			// if(/* dp.lam[ii] < 0.75 */ pi.surf == 1)
-			// {
-			// 	RVi += (fvar.sig/pi.rho * curve * dp.norm[ii].normalized())/correc;
-			// }
+			#ifdef CSF
+			if(dp.lam[ii] < 0.75 /* pi.surf == 1 */)
+			{
+				RVi += (fvar.sig/pi.rho * curve * pi.norm)/correc;
+			}
+			#endif
+
+			#ifdef HESF
+			surfT *= (0.02/2.0)*(pi.m/pi.rho);
+			#endif
 			
 			// #pragma omp critical
 			// Force += aero;	
-
 			
-			if( pi.b == PartState.FREE_ )
-				RV[ii] += (RVi + artViscI + viscI + surfT/pi.m /* + aero/pi.m */ + g);
-			else
-				RV[ii] += (RVi + artViscI + viscI + surfT/pi.m /* + aero/pi.m */);
+			#ifdef NOFROZEN
+				#ifdef ALE
+				RV[ii] += (RVi/pi.rho + RVia + artViscI + viscI + surfT/pi.m /* + aero/pi.m */ + g);
+				#else
+				RV[ii] += (RVi/pi.rho + artViscI + viscI + surfT/pi.m /* + aero/pi.m */ + g);
+				#endif
 
-			#ifdef DSPH
-			Rrho[ii] = (Rrhoi - fvar.dCont * Rrhod);
+				#ifndef NODSPH
+					#ifdef ALE
+					Rrho[ii] = Rrhoi*pi.rho + Rrhoc + fvar.dCont * Rrhod;
+					#else
+					Rrho[ii] = Rrhoi*pi.rho + fvar.dCont * Rrhod;
+					#endif 
+				#else
+					Rrho[ii] = Rrhoi*pi.rho;
+				#endif
+				
 			#else
-			Rrho[ii] = Rrhoi;
+				#ifdef ALE
+				RV[ii] += (RVi/pi.rho + RVia + pnp1[ii].aVisc + viscI + surfT/pi.m /* + aero/pi.m */ + g);
+				#else
+				RV[ii] += (RVi/pi.rho + pnp1[ii].aVisc + viscI + surfT/pi.m /* + aero/pi.m */ + g);
+				#endif
+				
+
+				#ifndef NODSPH
+					#ifdef ALE
+					Rrho[ii] = Rrhoi*pi.rho + Rrhoc + pnp1[ii].deltaD;
+					#else
+					Rrho[ii] = Rrhoi*pi.rho + pnp1[ii].deltaD;
+					#endif 
+				#else
+					Rrho[ii] = Rrhoi*pi.rho;
+				#endif
+
 			#endif
 			// res_.emplace_back(aero/pi.m);
 			// Rrho_.emplace_back(0.0);

--- a/src/Runge_Kutta.h
+++ b/src/Runge_Kutta.h
@@ -53,7 +53,7 @@ real Get_First_RK(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& 
 	Get_Boundary_Pressure(fvar,start,outlist,st_2);
 	Forces(svar, fvar, avar, cells, st_2, outlist, dp, res_1, Rrho_1, Af, Force);
 
-	#pragma omp parallel shared(svar,pn,st_2) /*reduction(+:Force,dropVel)*/
+	#pragma omp parallel default(shared) // shared(svar,pn,st_2) /*reduction(+:Force,dropVel)*/
 	{
 		if(svar.Asource == 2)
 		{
@@ -89,7 +89,7 @@ real Get_First_RK(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& 
 			/* PIPE = in the pipe, with free motion                         */
 			/* FREE = free of the pipe and receives an aero force           */
 
-			if(st_2[ii].b > PartState.BUFFER_)
+			if(st_2[ii].b > BUFFER)
 			{	
 
 				// Step_1(dt,pn[ii].xi,pn[ii].v,pn[ii].rho,pn[ii].acc,pn[ii].Rrho,
@@ -101,14 +101,16 @@ real Get_First_RK(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& 
 				#endif
 
 				st_2[ii].v = pn[ii].v + 0.5 * dt * res_1[ii];
-				st_2[ii].rho = pn[ii].rho + 0.5 * dt * Rrho_1[ii];
-				st_2[ii].p = B*(pow(st_2[ii].rho/fvar.rho0,gam)-1);
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, 
+								pn[ii].rho + 0.5 * dt * Rrho_1[ii]));
+				st_2[ii].rho = rho;
+				st_2[ii].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 				// st_2[ii].p = fvar.Cs*fvar.Cs * (st_2[ii].rho - fvar.rho0);
 				st_2[ii].acc = res_1[ii];
 				st_2[ii].Af = Af[ii];
 				st_2[ii].Rrho = Rrho_1[ii];
 
-				if(svar.Asource == 2 && st_2[ii].b == PartState.FREE_)
+				if(svar.Asource == 2 && st_2[ii].b == FREE)
 				{
 					#pragma omp atomic
 						cells.fNum[st_2[ii].cellID]++;
@@ -138,10 +140,16 @@ real Get_First_RK(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& 
 			{ /* Define buffer off the back particle */
 				size_t const &buffID = svar.buffer[ii][jj];
 
-				real frac = std::min(1.0, real(jj + 1) / 3.0);
+				// real frac = std::min(1.0, real(jj + 1) / 3.0);
 
-				st_2[buffID].rho = frac * fvar.rhoJ + (1.0 - frac) * (pn[buffID].rho + dt * Rrho_1[buffID]);
-				st_2[buffID].p = frac * fvar.pPress + (1.0 - frac) * (B * (pow(st_2[buffID].rho / fvar.rho0, gam) - 1));
+				// st_2[buffID].rho = frac * fvar.rhoJ + (1.0 - frac) * (pn[buffID].rho + dt * Rrho_1[buffID]);
+				// st_2[buffID].p = frac * fvar.pPress + (1.0 - frac) * (B * (pow(st_2[buffID].rho / fvar.rho0, gam) - 1));
+				
+				st_2[buffID].Rrho = Rrho_1[buffID];
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, 
+								pn[buffID].rho + 0.5 * dt * Rrho_1[buffID]));
+				st_2[buffID].rho = rho;
+				st_2[buffID].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 
 				st_2[buffID].xi = pn[buffID].xi + dt * pn[buffID].v;
 			}
@@ -191,7 +199,7 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 	Get_Boundary_Pressure(fvar,start,outlist,st_2);
 	Forces(svar, fvar, avar, cells, st_2, outlist, dp, res_2, Rrho_2, Af, Force);
 
-	#pragma omp parallel shared(svar,pn,st_2,res_2,Rrho_2,st_3,res_3,Rrho_3)
+	#pragma omp parallel default(shared) // shared(svar,pn,st_2,res_2,Rrho_2,st_3,res_3,Rrho_3)
 	{
 		
 		// #pragma omp for schedule(static) nowait
@@ -211,7 +219,7 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 			/* PIPE = in the pipe, with free motion                         */
 			/* FREE = free of the pipe and receives an aero force           */
 
-			if(st_3[ii].b > PartState.BUFFER_)
+			if(st_3[ii].b > BUFFER)
 			{	
 				#ifdef ALE
 				st_3[ii].xi = pn[ii].xi + 0.5 * dt * (st_2[ii].v + st_2[ii].vPert);
@@ -220,10 +228,10 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 				#endif
 
 				st_3[ii].v = pn[ii].v + 0.5 * dt * res_2[ii];
-				st_3[ii].rho = pn[ii].rho + 0.5 * dt * Rrho_2[ii];
-				st_3[ii].p = B * (pow(st_3[ii].rho / fvar.rho0, gam) - 1);
-				// st_3[ii].p = fvar.Cs*fvar.Cs * (st_3[ii].rho - fvar.rho0);
-
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, 
+								pn[ii].rho + 0.5 * dt * Rrho_2[ii]));
+				st_3[ii].rho = rho;
+				st_3[ii].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 			}
 
 		}
@@ -236,10 +244,14 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 			{ /* Define buffer off the back particle */
 				size_t const &buffID = svar.buffer[ii][jj];
 
-				real frac = std::min(1.0, real(jj + 1) / 3.0);
-
-				st_3[buffID].rho = frac * fvar.rhoJ + (1.0 - frac) * (pn[buffID].rho + dt * Rrho_2[buffID]);
-				st_3[buffID].p = frac * fvar.pPress + (1.0 - frac) * (B * (pow(st_3[buffID].rho / fvar.rho0, gam) - 1));
+				// real const frac = std::min(1.0, real(jj + 1) / 3.0);
+				// real const rho = frac * fvar.rhoJ + (1.0 - frac) * (pn[buffID].rho + dt * Rrho_2[buffID]); 
+				// st_3[buffID].rho = rho;
+				// st_3[buffID].p = frac * fvar.pPress + (1.0 - frac) * pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, 
+								 pn[buffID].rho + 0.5 * dt * Rrho_2[buffID]));
+				st_3[buffID].rho = rho;
+				st_3[buffID].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 
 				st_3[buffID].xi = pn[buffID].xi + dt * pn[buffID].v;
 			}
@@ -264,7 +276,7 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 	Get_Boundary_Pressure(fvar,start,outlist,st_3);
 	Forces(svar, fvar, avar, cells, st_3, outlist, dp, res_3, Rrho_3, Af, Force);
 
-	#pragma omp parallel shared(svar,pn,st_3,res_3,Rrho_3,st_4,res_4,Rrho_4)
+	#pragma omp parallel default(shared) // shared(svar,pn,st_3,res_3,Rrho_3,st_4,res_4,Rrho_4)
 	{
 		#pragma omp for schedule(static) nowait
 		for (size_t ii=start; ii < end; ++ii)
@@ -276,13 +288,13 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 			/* FREE = free of the pipe and receives an aero force           */
 
 			/*Check if the particle is clear of the starting area*/
-			// if(st_3[ii].b == PartState.START_ || st_3[ii].b == PartState.BACK_)
+			// if(st_3[ii].b == START || st_3[ii].b == BACK)
 			// {   
 			// 	/*For the particles marked 1, perform a prescribed motion*/
 			// 	st_4[ii].xi = pn[ii].xi + dt*pn[ii].v;
 			// }
 
-			if(st_4[ii].b > PartState.BUFFER_)
+			if(st_4[ii].b > BUFFER)
 			{	
 				#ifdef ALE
 				st_4[ii].xi = pn[ii].xi + dt * (st_3[ii].v + st_3[ii].vPert);
@@ -291,8 +303,9 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 				#endif
 
 				st_4[ii].v = pn[ii].v + dt * res_3[ii];
-				st_4[ii].rho = pn[ii].rho + dt * Rrho_3[ii];
-				st_4[ii].p = B*(pow(st_4[ii].rho/fvar.rho0,gam)-1);
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, pn[ii].rho + dt * Rrho_3[ii]));
+				st_4[ii].rho = rho;
+				st_4[ii].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 				// st_4[ii].p = fvar.Cs*fvar.Cs * (st_4[ii].rho - fvar.rho0);
 			}
 		}
@@ -305,10 +318,14 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 			{ /* Define buffer off the back particle */
 				size_t const &buffID = svar.buffer[ii][jj];
 
-				real frac = std::min(1.0, real(jj + 1) / 3.0);
-
-				st_4[buffID].rho = frac * fvar.rhoJ + (1.0 - frac) * (pn[buffID].rho + dt * Rrho_3[buffID]);
-				st_4[buffID].p = frac * fvar.pPress + (1.0 - frac) * (B * (pow(st_4[buffID].rho / fvar.rho0, gam) - 1));
+				// real frac = std::min(1.0, real(jj + 1) / 3.0);
+				// real const rho = frac * fvar.rhoJ + (1.0 - frac) * (pn[buffID].rho + dt * Rrho_3[buffID]);
+				// st_4[buffID].rho = rho;
+				// st_4[buffID].p = frac * fvar.pPress + (1.0 - frac) * pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, 
+								pn[buffID].rho + 0.5 * dt * Rrho_3[buffID]));
+				st_4[buffID].rho = rho;
+				st_4[buffID].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 				st_4[buffID].xi = pn[buffID].xi + dt * pn[buffID].v;
 			}
 		}
@@ -331,7 +348,7 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 	Get_Boundary_Pressure(fvar,start,outlist,st_4);
 	Forces(svar, fvar, avar, cells, st_4, outlist, dp, res_4, Rrho_4, Af, Force);
 
-	#pragma omp parallel shared(svar,pn,pnp1,st_2,res_2,Rrho_2,st_3,res_3,Rrho_3,st_4,res_4,Rrho_4)
+	#pragma omp parallel default(shared) // shared(svar,pn,pnp1,st_2,res_2,Rrho_2,st_3,res_3,Rrho_3,st_4,res_4,Rrho_4)
 	{
 		if(svar.Asource == 2)
 		{
@@ -344,50 +361,20 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 					cells.vFnp1[ii] = StateVecD::Zero();
 			}
 		}
-	
-		#pragma omp for schedule(static) nowait
-		for (size_t ii=0; ii < start; ++ii)
-		{	/****** BOUNDARY PARTICLES ***********/
-			pnp1[ii].rho = pn[ii].rho + 
-				(dt/6.0) * (pn[ii].Rrho + 2.0 * Rrho_2[ii] + 2.0 * Rrho_3[ii] + Rrho_4[ii]);
-			pnp1[ii].p = B*(pow(pnp1[ii].rho/fvar.rho0,gam)-1);
-			// pnp1[ii].p = fvar.Cs*fvar.Cs * (pnp1[ii].rho - fvar.rho0);
 
-			pnp1[ii].acc = res_4[ii];
-			pnp1[ii].Rrho = Rrho_4[ii];
-		}
 
 		#pragma omp for schedule(static) nowait
 		for (size_t ii=start; ii < end; ++ii)
 		{	/****** FLUID PARTICLES **************/
 			
-			/* START = pipe particle receiving prescribed motion            */
-			/* BACK = the latest particle in that column                    */
-			/* PIPE = in the pipe, with free motion                         */
-			/* FREE = free of the pipe and receives an aero force           */
-
-			/*Check if the particle is clear of the starting area*/
-			// if(pnp1[ii].b == PartState.START_ || pnp1[ii].b == PartState.BACK_)
-			// {   
-			// 	StateVecD vec = svar.Transp*(pnp1[ii].xi-svar.Start);
-			// 	if(vec(1) > svar.clear)
-			// 	{	/*Tag it as clear if it's higher than the plane of the exit*/
-			// 		pnp1[ii].b=PartState.PIPE_;
-			// 	}
-			// 	else
-			// 	{	/*For the particles marked 1, perform a prescribed motion*/
-			// 		pnp1[ii].xi = pn[ii].xi + dt*pn[ii].v;
-			// 	}
-			// }
-
-			if(pnp1[ii].b > PartState.BUFFER_)
+			if(pnp1[ii].b > BUFFER)
 			{	
-				if(pnp1[ii].b == PartState.PIPE_)
+				if(pnp1[ii].b == PIPE)
 				{	/*Do a check to see if it needs to be given an aero force*/
 					StateVecD vec = svar.Transp*(st_4[ii].xi-svar.sim_start);
 					if(vec(1) > 0.0)
 					{
-						pnp1[ii].b = PartState.FREE_;
+						pnp1[ii].b = FREE;
 						if(svar.Asource == 1 || svar.Asource == 2)
 						{
 							/*retrieve the cell it's in*/
@@ -426,17 +413,17 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 				pnp1[ii].v = pn[ii].v + 
 					(dt/6.0) * (st_2[ii].acc + 2.0 * res_2[ii] + 2.0 * res_3[ii] + res_4[ii]);
 
-				pnp1[ii].rho = pn[ii].rho + (dt / 6.0) * 
-					(st_2[ii].Rrho + 2.0 * Rrho_2[ii] + 2.0 * Rrho_3[ii] + Rrho_4[ii]);
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, pn[ii].rho + (dt / 6.0) * 
+					(st_2[ii].Rrho + 2.0 * Rrho_2[ii] + 2.0 * Rrho_3[ii] + Rrho_4[ii])));
+				pnp1[ii].rho = rho;
 
-				pnp1[ii].p = B*(pow(pnp1[ii].rho/fvar.rho0,gam)-1);
-				// pnp1[ii].p = fvar.Cs*fvar.Cs * (pnp1[ii].rho - fvar.rho0);
+				pnp1[ii].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 
 				pnp1[ii].acc = res_4[ii];
 				pnp1[ii].Af = Af[ii];
 				pnp1[ii].Rrho = Rrho_4[ii];
 
-				if(svar.Asource == 2 && pnp1[ii].b == PartState.FREE_)
+				if(svar.Asource == 2 && pnp1[ii].b == FREE)
 				{
 					#pragma omp atomic
 						cells.fNum[pnp1[ii].cellID]++;
@@ -463,17 +450,22 @@ void Perform_RK4(KDTREE const& TREE, SIM& svar, FLUID const& fvar, AERO const& a
 			{ /* Define buffer off the back particle */
 				size_t const &buffID = svar.buffer[ii][jj];
 
-				real frac = std::min(1.0, real(jj + 1) / 3.0);
+				// real frac = std::min(1.0, real(jj + 1) / 3.0);
 
 				pnp1[buffID].Rrho = Rrho_4[buffID];
-				pnp1[buffID].rho = frac * fvar.rhoJ + (1.0 - frac) * 
-								(pn[buffID].rho + (dt / 6.0) * 
-								(st_2[buffID].Rrho + 2.0 * Rrho_2[buffID] + 
-								 2.0 * Rrho_3[buffID] + Rrho_4[buffID]));
 
-				pnp1[buffID].p = frac * fvar.pPress + (1.0 - frac) * 
-							(B * (pow(pnp1[buffID].rho / fvar.rho0, gam) - 1));
+				// real const rho = frac * fvar.rhoJ + (1.0 - frac) * 
+				// 				(pn[buffID].rho + (dt / 6.0) * 
+				// 				(st_2[buffID].Rrho + 2.0 * Rrho_2[buffID] + 
+				// 				 2.0 * Rrho_3[buffID] + Rrho_4[buffID]));
+				// pnp1[buffID].rho = rho;
 
+				// pnp1[buffID].p = frac * fvar.pPress + (1.0 - frac) * pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
+				real const rho = std::max(fvar.rhoMin, std::min(fvar.rhoMax, pn[buffID].rho + (dt / 6.0) * 
+					(st_2[buffID].Rrho + 2.0 * Rrho_2[buffID] + 2.0 * Rrho_3[buffID] + Rrho_4[buffID])));
+				pnp1[buffID].rho = rho;
+
+				pnp1[buffID].p = pressure_equation(rho,fvar.B,fvar.gam,fvar.Cs,fvar.rho0);
 				pnp1[buffID].xi = pn[buffID].xi + dt * pn[buffID].v;
 			}
 		}


### PR DESCRIPTION
A number of additions have been implemented, the first being a limiter option for the density variation. This helps to prevent simulations going out of control, as some were observed to have small areas 'pop' and explode presumably due to divergence of density. Control is still advised with the speed of sound, but this provides a numerical bounding for stability, and should be imposed only on unphysical densities. 
A new library has also been included to perform a drag sweep for a spherical droplet, and benchmark the coupling forces. 
A bug has also been fixed where a check for restart files is done before the boundary setting is defined, breaking restarts in simulations that include the boundary. It should be intended at some point to write simulation settings to the auxiliary data of the output files, and read key settings from there (such as frame timings and particle spacing), should the para files differ.